### PR TITLE
Allow access to escaping values for table query

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ FiddlerCore is required by:
 - Test\FaultInjection\AzureStoreMangler
 - Test\WindowsDesktop
 
-This dependency is not included and must be downloaded from [http://www.fiddler2.com/Fiddler/Core/](http://www.fiddler2.com/Fiddler/Core/).
+This dependency is not included and must be downloaded from [http://www.telerik.com/fiddler/fiddlercore](http://www.telerik.com/fiddler/fiddlercore).
 
 Once installed:
 

--- a/Test/FaultInjection/Dependencies/DotNet2/README.txt
+++ b/Test/FaultInjection/Dependencies/DotNet2/README.txt
@@ -1,2 +1,2 @@
-Please download FiddlerCore @ http://www.fiddler2.com/Fiddler/Core/
+Please download FiddlerCore @ http://www.telerik.com/fiddler/fiddlercore
 Please place FiddlerCore.dll here

--- a/Test/FaultInjection/Dependencies/DotNet4/README.txt
+++ b/Test/FaultInjection/Dependencies/DotNet4/README.txt
@@ -1,3 +1,3 @@
-Please download FiddlerCore @ http://www.fiddler2.com/Fiddler/Core/
+Please download FiddlerCore @ http://www.telerik.com/fiddler/fiddlercore
 
 Please place FiddlerCore4.dll here

--- a/Test/FaultInjection/Dependencies/README.txt
+++ b/Test/FaultInjection/Dependencies/README.txt
@@ -1,4 +1,4 @@
-Please download FiddlerCore @ http://www.fiddler2.com/Fiddler/Core/
+Please download FiddlerCore @ http://www.telerik.com/fiddler/fiddlercore
 
 FiddlerCore.dll needs to be placed in .\DotNet2
 FiddlerCore4.dll needs to be placed in .\DotNet4


### PR DESCRIPTION
Allows the ability to directly call the value escaping functionality of generating a table filter condition.

Also fix links in README's to FiddlerCore.