### PR TITLE
Use CultureInfo.InvariantCulture when parsing DateTimeOffset values.

### DIFF
--- a/Lib/ClassLibraryCommon/Analytics/LogRecordStreamReader.cs
+++ b/Lib/ClassLibraryCommon/Analytics/LogRecordStreamReader.cs
@@ -180,7 +180,7 @@ namespace Microsoft.WindowsAzure.Storage.Analytics
                 bool parsed = DateTimeOffset.TryParseExact(
                     temp,
                     format,
-                    null /* provider */,
+                    CultureInfo.InvariantCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
                     out tempDateTime);
                 if (parsed)

--- a/Test/WindowsDesktop/Analytics/LogRecordStreamReaderTests.cs
+++ b/Test/WindowsDesktop/Analytics/LogRecordStreamReaderTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.WindowsAzure.Storage.Analytics
+{
+    [TestClass]
+    public class LogRecordStreamReaderTests
+    {
+        [TestMethod]
+        [Description("Verify that DateTimeOffset can be read altough current thread has a non-english culture.")]
+        [TestCategory(ComponentCategory.Blob)]
+        [TestCategory(TestTypeCategory.UnitTest)]
+        [TestCategory(SmokeTestCategory.NonSmoke)]
+        public void ReadDateTimeOffsetValueWithNonEnglishCulture()
+        {
+            // Remember current culture setting
+            CultureInfo originalThreadCulture = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                // Use culture 'Swedish (Sweden)' for testing
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("sv-SE");
+
+                // Create reader instance with a single date field to be parsed
+                const string input = "Wednesday, 03-Dec-14 08:59:27 GMT;";
+                LogRecordStreamReader reader = new LogRecordStreamReader(new MemoryStream(Encoding.UTF8.GetBytes(input)), 100);
+
+                // The format used in analytics
+                const string format = "dddd, dd-MMM-yy HH:mm:ss 'GMT'";
+
+                // Parse the input date
+                DateTimeOffset? actual = reader.ReadDateTimeOffset(format);
+
+                // Assert that it was read properly
+                Assert.IsTrue(actual.HasValue);
+                Assert.AreEqual(2014, actual.Value.Year);
+                Assert.AreEqual(12, actual.Value.Month);
+                Assert.AreEqual(3, actual.Value.Day);
+                Assert.AreEqual(8, actual.Value.Hour);
+                Assert.AreEqual(59, actual.Value.Minute);
+                Assert.AreEqual(27, actual.Value.Second);
+                Assert.AreEqual(TimeSpan.Zero, actual.Value.Offset);
+            }
+            finally
+            {
+                // Restore original culture setting
+                Thread.CurrentThread.CurrentCulture = originalThreadCulture;
+            }
+        }
+    }
+}

--- a/Test/WindowsDesktop/Microsoft.WindowsAzure.Storage.Test.csproj
+++ b/Test/WindowsDesktop/Microsoft.WindowsAzure.Storage.Test.csproj
@@ -75,6 +75,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Analytics\LogRecordStreamReaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WCFBufferManagerAdapter.cs" />
   </ItemGroup>


### PR DESCRIPTION
This fix allow log records to be parsed when the current culture is non-English.

The added unit test will fail without the fix.

See: http://stackoverflow.com/q/27268777/688958