### PR TITLE
Handle scenario for virtual property and setter has not been overridden

### DIFF
--- a/Lib/Common/Core/Util/PlatformAgnosticReflectionExtensions.cs
+++ b/Lib/Common/Core/Util/PlatformAgnosticReflectionExtensions.cs
@@ -70,7 +70,19 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
 #if WINDOWS_RT || NETCORE
             return property.GetMethod;
 #else
-            return property.GetGetMethod();
+            var getMethod = property.GetGetMethod();
+            if (getMethod == null)
+            {
+                var setMethod = property.GetSetMethod();
+                if (setMethod.IsVirtual)
+                {
+                    var parentType = setMethod.DeclaringType.BaseType;
+                    var parentProperty = parentType.GetProperty(property.Name, property.PropertyType);
+                    if (parentProperty != null)
+                        return parentProperty.FindGetProp();
+                }
+            }
+            return getMethod;
 #endif
         }
 
@@ -79,7 +91,19 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
 #if WINDOWS_RT || NETCORE
             return property.SetMethod;
 #else
-            return property.GetSetMethod();
+            var setMethod = property.GetSetMethod();
+            if (setMethod == null)
+            {
+                var getMethod = property.GetGetMethod();
+                if (getMethod.IsVirtual)
+                {
+                    var parentType = getMethod.DeclaringType.BaseType;
+                    var parentProperty = parentType.GetProperty(property.Name, property.PropertyType);
+                    if (parentProperty != null)
+                        return parentProperty.FindSetProp();
+                }
+            }
+            return setMethod;
 #endif
         }
     }

--- a/Test/ClassLibraryCommon/Table/TableOperationUnitTests.cs
+++ b/Test/ClassLibraryCommon/Table/TableOperationUnitTests.cs
@@ -2824,6 +2824,31 @@ namespace Microsoft.WindowsAzure.Storage.Table
         }
 
         [TestMethod]
+        [Description("TableOperations with entities that have Virtual Properties")]
+        [TestCategory(ComponentCategory.Table)]
+        [TestCategory(TestTypeCategory.UnitTest)]
+        [TestCategory(SmokeTestCategory.NonSmoke)]
+        [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
+        public void TableOpsWithEntitiesVirtualProperties()
+        {
+            var azureObject = new DerivedEntity()
+            {
+                PartitionKey = "PK",
+                RowKey = "RK",
+                VirtualProperty = "Test Virtual Property",
+            };
+
+            IDictionary<string, EntityProperty> properties = azureObject.WriteEntity(null);
+            Assert.AreEqual(1, properties.Count);
+            Assert.AreEqual(azureObject.VirtualProperty, properties["VirtualProperty"].StringValue);
+
+            OperationContext context = new OperationContext();
+            var ent = new DerivedEntity();
+            ent.ReadEntity(properties, context);
+            Assert.AreEqual(properties["VirtualProperty"].StringValue, ent.VirtualProperty);
+        }
+
+        [TestMethod]
         [Description("Simple test to roundtrip a non derived TableEntity with and without CompiledSerializers")]
         [TestCategory(ComponentCategory.Table)]
         [TestCategory(TestTypeCategory.UnitTest)]


### PR DESCRIPTION
This is not a complete PR, but is more of a proof-of-concept of a bug that we've come across and would like to explore fixing. I've only modified code for the desktop version of the library currently.

Basically we have some virtual properties on some objects where we only override the get method. Because of this, when the library is reflecting through the object to work out what to serialize these properties are getting left off because they don't appear to have any setters defined. This seems to be a quirk in the way Reflection works as they do have setters defined, but in a parent class. C# lets you just override the getter and then access the underlying setter transparently as code.

I've made a change to the way Getters and Setters are retrieved so that if they are declared as virtual we check to see if one was specified on the parent class.

I'm interested in what people think about this idea primarily, and the implementation secondarily.
