### PR TITLE
Update FiddlerCore URL and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ TestResults/
 
 #VS14 sln.ide files
 *.sln.ide/
+
+# FaultInjection dependencies
+Test/FaultInjection/Dependencies/**/*.dll

--- a/Test/FaultInjection/Dependencies/DotNet2/README.txt
+++ b/Test/FaultInjection/Dependencies/DotNet2/README.txt
@@ -1,2 +1,3 @@
-Please download FiddlerCore @ http://www.fiddler2.com/Fiddler/Core/
+Please download FiddlerCore @ http://www.telerik.com/fiddler/fiddlercore
+
 Please place FiddlerCore.dll here

--- a/Test/FaultInjection/Dependencies/DotNet4/README.txt
+++ b/Test/FaultInjection/Dependencies/DotNet4/README.txt
@@ -1,3 +1,3 @@
-Please download FiddlerCore @ http://www.fiddler2.com/Fiddler/Core/
+Please download FiddlerCore @ http://www.telerik.com/fiddler/fiddlercore
 
 Please place FiddlerCore4.dll here

--- a/Test/FaultInjection/Dependencies/README.txt
+++ b/Test/FaultInjection/Dependencies/README.txt
@@ -1,4 +1,4 @@
-Please download FiddlerCore @ http://www.fiddler2.com/Fiddler/Core/
+Please download FiddlerCore @ http://www.telerik.com/fiddler/fiddlercore
 
 FiddlerCore.dll needs to be placed in .\DotNet2
 FiddlerCore4.dll needs to be placed in .\DotNet4


### PR DESCRIPTION
- Point to the new FiddlerCore location
  (http://www.fiddler2.com/Fiddler/Core/)
- Update gitignore to ignore DLLs in the FaultInjection Dependencies
  directory