### PR TITLE
Add interface to cloud queue client to aid mocking.

### DIFF
--- a/Lib/ClassLibraryCommon/Queue/CloudQueueClient.cs
+++ b/Lib/ClassLibraryCommon/Queue/CloudQueueClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.WindowsAzure.Storage.Queue
     /// Provides a client-side logical representation of the Windows Azure Queue service. This client is used to configure and execute requests against the Queue service.
     /// </summary>
     /// <remarks>The service client encapsulates the endpoint or endpoints for the Queue service. If the service client will be used for authenticated access, it also encapsulates the credentials for accessing the storage account.</remarks>
-    public sealed partial class CloudQueueClient
+    public sealed partial class CloudQueueClient : ICloudQueueClient
     {
         private IAuthenticationHandler authenticationHandler;
 

--- a/Lib/ClassLibraryCommon/Queue/ICloudQueueClient.cs
+++ b/Lib/ClassLibraryCommon/Queue/ICloudQueueClient.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.WindowsAzure.Storage.Queue
+{
+    /// <summary>
+    /// The cloud queue client.
+    /// </summary>
+    public interface ICloudQueueClient
+    {
+        /// <summary>
+        /// Returns a reference to a <see cref="CloudQueue"/> object with the specified name.
+        /// </summary>
+        /// <param name="queueName">A string containing the name of the queue.</param>
+        /// <returns>A <see cref="CloudQueue"/> object.</returns>
+        CloudQueue GetQueueReference(string queueName);
+    }
+}

--- a/Lib/Common/CloudStorageAccount.cs
+++ b/Lib/Common/CloudStorageAccount.cs
@@ -37,7 +37,7 @@ namespace Microsoft.WindowsAzure.Storage
     /// <summary>
     /// Represents a Windows Azure Storage account.
     /// </summary>
-    public sealed class CloudStorageAccount
+    public sealed class CloudStorageAccount : ICloudStorageAccount
     {
         /// <summary>
         /// The FISMA compliance default value.

--- a/Lib/WindowsDesktop/ICloudStorageAccount.cs
+++ b/Lib/WindowsDesktop/ICloudStorageAccount.cs
@@ -1,0 +1,41 @@
+namespace Microsoft.WindowsAzure.Storage
+{
+    using Microsoft.WindowsAzure.Storage.Analytics;
+    using Microsoft.WindowsAzure.Storage.Blob;
+    using Microsoft.WindowsAzure.Storage.File;
+    using Microsoft.WindowsAzure.Storage.Queue;
+    using Microsoft.WindowsAzure.Storage.Table;
+
+    public interface ICloudStorageAccount
+    {
+        /// <summary>
+        /// Creates the Table service client.
+        /// </summary>
+        /// <returns>A <see cref="CloudTableClient"/> object.</returns>
+        CloudTableClient CreateCloudTableClient();
+
+        /// <summary>
+        /// Creates the Queue service client.
+        /// </summary>
+        /// <returns>A <see cref="CloudQueueClient"/> object.</returns>
+        CloudQueueClient CreateCloudQueueClient();
+
+        /// <summary>
+        /// Creates the Blob service client.
+        /// </summary>
+        /// <returns>A <see cref="CloudBlobClient"/> object.</returns>
+        CloudBlobClient CreateCloudBlobClient();
+
+        /// <summary>
+        /// Creates an analytics client.
+        /// </summary>
+        /// <returns>A <see cref="CloudAnalyticsClient"/> object.</returns>
+        CloudAnalyticsClient CreateCloudAnalyticsClient();
+
+        /// <summary>
+        /// Creates the File service client.
+        /// </summary>
+        /// <returns>A client object that specifies the File service endpoint.</returns>
+        CloudFileClient CreateCloudFileClient();
+    }
+}


### PR DESCRIPTION
When using the CloudQueueClient class within my projects I find it very hard to mock the dependency due to it not having an interface.

I have implemented a very simple interface that could be expanded to allow more methods to be mocked.