### PR TITLE
Buffer Manager instance usage  is interchanged

### DIFF
--- a/Test/Common/TestBase.Common.cs
+++ b/Test/Common/TestBase.Common.cs
@@ -94,7 +94,7 @@ namespace Microsoft.WindowsAzure.Storage
             client.AuthenticationScheme = DefaultAuthenticationScheme;
 
 #if WINDOWS_DESKTOP
-            client.BufferManager = BlobBufferManager;
+            client.BufferManager = TableBufferManager;
 #endif
 
             return client;
@@ -119,7 +119,7 @@ namespace Microsoft.WindowsAzure.Storage
             client.AuthenticationScheme = DefaultAuthenticationScheme;
 
 #if WINDOWS_DESKTOP
-            client.BufferManager = TableBufferManager;
+            client.BufferManager = BlobBufferManager;
 #endif
 
             return client;


### PR DESCRIPTION
In CloudTableClient to use the BlobBufferManager, In CloudBlobClient to use the TableBufferManager.