### PR TITLE
Fix comments of ConvertDateTimeToHttpString

### DIFF
--- a/Lib/Common/Core/Util/HttpWebUtility.cs
+++ b/Lib/Common/Core/Util/HttpWebUtility.cs
@@ -87,15 +87,15 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
         }
 
         /// <summary>
-        /// Converts the DateTimeOffset object to an Http string of form: Sun, 28 Jan 2008 12:11:37 GMT.
+        /// Converts the DateTimeOffset object to an Http string of form: Mon, 28 Jan 2008 12:11:37 GMT.
         /// </summary>
         /// <param name="dateTime">The DateTimeOffset object to convert to an Http string.</param>
-        /// <returns>String of form: Sun, 28 Jan 2008 12:11:37 GMT.</returns>
+        /// <returns>String of form: Mon, 28 Jan 2008 12:11:37 GMT.</returns>
         public static string ConvertDateTimeToHttpString(DateTimeOffset dateTime)
         {
             // 'R' means rfc1123 date which is what the storage services use for all dates...
             // It will be in the following format:
-            // Sun, 28 Jan 2008 12:11:37 GMT
+            // Mon, 28 Jan 2008 12:11:37 GMT
             return dateTime.UtcDateTime.ToString("R", CultureInfo.InvariantCulture);
         }
 


### PR DESCRIPTION
The comments of HttpWebUtility.ConvertDateTimeToHttpString has a mistake. 28 Jan 2008 should be Monday, rather than Sunday.