### PR TITLE
Fixed a bug in TableQuery where an encrypted table would break select

### DIFF
--- a/Lib/ClassLibraryCommon/Table/TableQuery.cs
+++ b/Lib/ClassLibraryCommon/Table/TableQuery.cs
@@ -538,7 +538,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
             requestOptions.AssertPolicyIfRequired();
 
             // If encryption policy is set, then add the encryption metadata column to Select columns in order to be able to decrypt properties.
-            if (requestOptions.EncryptionPolicy != null && query.SelectColumns != null)
+            if (requestOptions.EncryptionPolicy != null && query.SelectColumns != null && query.SelectColumns.Count > 0)
             {
                 query.SelectColumns.Add(Constants.EncryptionConstants.TableEncryptionKeyDetails);
                 query.SelectColumns.Add(Constants.EncryptionConstants.TableEncryptionPropertyDetails);


### PR DESCRIPTION
Encrypting a table with client side encryption and then using a LINQ query against a TableQuery<T> would cause the query to have the two encryption metadata columns explicitly added to the select columns collection.

This would happen even if the collection was empty and the default behaviour of selecting all columns was being invoked. The effect would be in this instance that the two columns would be added resulting in only the PartitionKey, RowKey, TimeStamp and two metadata columns being selected and not all of the columns as expected.

Added a .Count check to the predicate along with the existing null check to account for the selected columns collection existing but being empty which is the default.