### PR TITLE
Binary compatibility fix for 6.0

### DIFF
--- a/Lib/ClassLibraryCommon/Table/TableBatchOperation.cs
+++ b/Lib/ClassLibraryCommon/Table/TableBatchOperation.cs
@@ -52,6 +52,20 @@ namespace Microsoft.WindowsAzure.Storage.Table
             this.Add(new TableOperation(null /* entity */, TableOperationType.Retrieve) { RetrievePartitionKey = partitionKey, RetrieveRowKey = rowKey, SelectColumns = selectedColumns, RetrieveResolver = (pk, rk, ts, prop, etag) => EntityUtilities.ResolveEntityByType<TElement>(pk, rk, ts, prop, etag) });
         }
 
+        // 6.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
+        /// <summary>
+        /// Inserts a <see cref="TableOperation"/> into the batch that retrieves an entity based on its row key and partition key. The entity will be deserialized into the specified class type which extends <see cref="ITableEntity"/>.
+        /// </summary>
+        /// <typeparam name="TElement">The class of type for the entity to retrieve.</typeparam>
+        /// <param name="partitionKey">A string containing the partition key of the entity to retrieve.</param>
+        /// <param name="rowKey">A string containing the row key of the entity to retrieve.</param>
+        [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter",
+            Justification = "Reviewed.")]
+        public void Retrieve<TElement>(string partitionKey, string rowKey) where TElement : ITableEntity
+        {
+            Retrieve<TElement>(partitionKey, rowKey, selectedColumns: null);
+        }
+
         /// <summary>
         /// Adds a table operation to retrieve an entity of the specified class type with the specified partition key and row key to the batch operation.
         /// </summary>


### PR DESCRIPTION
Adding optional parameters means that dependent libraries need to be recompiled otherwise they fail with missing method exceptions. I've taken the [guidance from the Roslyn team](https://github.com/dotnet/roslyn/blob/master/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md) to backfill a gap and I'd appreciate it if this could make it in to 6.1.1 please.