### PR TITLE
Fixed CloudBlockBlob.AcquireLease leaseTime parameter boundary check

### DIFF
--- a/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
@@ -3271,7 +3271,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(1), TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 

--- a/Lib/WindowsRuntime/Blob/CloudBlob.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlob.cs
@@ -1761,7 +1761,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(1), TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 


### PR DESCRIPTION
Replaced by PR #236

This is related to #232 
As outlined in the issue the original boundary check values of `Timespan.FromSeconds(1)` and `Timespan.MaxValue` were not in sync with the boundary checks performed by the REST endpoint. This fixes that.