### PR TITLE
Prevent TestConfigurations.xml and creds from getting into repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ Lib/AspNet/Microsoft.WindowsAzure.Storage/project.lock.json
 Test/AspNet/Microsoft.WindowsAzure.Storage.Test/project.lock.json
 Test/AspNet/XUnitForMsTest/project.lock.json
 UpgradeLog.htm
+Test/FaultInjection/Dependencies/DotNet2/FiddlerCore.dll
+Test/FaultInjection/Dependencies/DotNet4/FiddlerCore4.dll

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ Test/AspNet/XUnitForMsTest/project.lock.json
 UpgradeLog.htm
 Test/FaultInjection/Dependencies/DotNet2/FiddlerCore.dll
 Test/FaultInjection/Dependencies/DotNet4/FiddlerCore4.dll
+Test/Common/LocalTestConfigurations.xml

--- a/BreakingChanges.txt
+++ b/BreakingChanges.txt
@@ -1,6 +1,7 @@
 Tracking Breaking Changes since 6.0
 
 - All: The dnx and net target frameworks have been unified, and DNXCore target framework has been renamed to Dotnet5.4. All DNX4.5.1 projects will take a dependency on the regular Windows Desktop dll.
+- Blobs: Change boundary checks for lease duration to be in line with those used in the REST endpoints
 
 Tracking Breaking Changes since 5.0
 

--- a/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
@@ -3271,7 +3271,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60));
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 
@@ -3407,7 +3407,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int? breakSeconds = null;
             if (breakPeriod.HasValue)
             {
-                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.Zero, TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 breakSeconds = (int)breakPeriod.Value.TotalSeconds;
             }
 

--- a/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
@@ -3271,7 +3271,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(1), TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 

--- a/Lib/ClassLibraryCommon/Blob/CloudBlobContainer.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlobContainer.cs
@@ -2368,7 +2368,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(1), TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 
@@ -2491,7 +2491,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int? breakSeconds = null;
             if (breakPeriod.HasValue)
             {
-                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.Zero, TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 breakSeconds = (int)breakPeriod.Value.TotalSeconds;
             }
 

--- a/Lib/Common/Shared/Protocol/Constants.cs
+++ b/Lib/Common/Shared/Protocol/Constants.cs
@@ -11,7 +11,7 @@
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
-//    limitations under the License.
+//    limitations under the License.f
 // </copyright>
 // -----------------------------------------------------------------------------------------
 
@@ -422,6 +422,16 @@ namespace Microsoft.WindowsAzure.Storage.Shared.Protocol
         /// Constant signaling the resource's lease is fixed (finite).
         /// </summary>
         public const string LeaseFixedValue = "fixed";
+
+        /// <summary>
+        /// Constant for the minimum duration of a lease.
+        /// </summary>
+        public const int MinimumLeaseDuration = 15;
+
+        /// <summary>
+        /// Constant for the maximum duration of a lease
+        /// </summary>
+        public const int MaximumLeaseDuration = 60;
 
         /// <summary>
         /// Constant for a pending copy.

--- a/Lib/WindowsRuntime/Blob/CloudBlob.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlob.cs
@@ -1761,7 +1761,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60));
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 
@@ -1889,7 +1889,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int? breakSeconds = null;
             if (breakPeriod.HasValue)
             {
-                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.Zero, TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 breakSeconds = (int)breakPeriod.Value.TotalSeconds;
             }
 

--- a/Lib/WindowsRuntime/Blob/CloudBlob.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlob.cs
@@ -1761,7 +1761,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(1), TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(60));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 

--- a/Lib/WindowsRuntime/Blob/CloudBlobContainer.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlobContainer.cs
@@ -1286,7 +1286,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int leaseDuration = -1;
             if (leaseTime.HasValue)
             {
-                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(1), TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("leaseTime", leaseTime.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 leaseDuration = (int)leaseTime.Value.TotalSeconds;
             }
 
@@ -1413,7 +1413,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             int? breakSeconds = null;
             if (breakPeriod.HasValue)
             {
-                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.Zero, TimeSpan.MaxValue);
+                CommonUtility.AssertInBounds("breakPeriod", breakPeriod.Value, TimeSpan.FromSeconds(Constants.MinimumLeaseDuration), TimeSpan.FromSeconds(Constants.MaximumLeaseDuration));
                 breakSeconds = (int)breakPeriod.Value.TotalSeconds;
             }
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Tests for the client-side encryption preview support also depend on KeyVault.Ext
 
 - [KeyVault.Extensions] (http://www.nuget.org/packages/Microsoft.Azure.KeyVault.Extensions)
 
+Running tests locally will require you to have an Azure account with a Storage container configured in it. To use this container you will need to make a copy of the /Test/Common/TestConfiguration.xml file in the same location and name that file LocalTestConfiguration.xml. The LocalTestConfiguration file is where you will need to enter in the keys and endpoints for the Azure Storage container that you want to use while testing.
+
 ## Code Samples
 
 > Note:

--- a/Test/ClassLibraryCommon/Blob/LeaseTests.cs
+++ b/Test/ClassLibraryCommon/Blob/LeaseTests.cs
@@ -1002,20 +1002,17 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 () => leasedBlob.AcquireLease(TimeSpan.FromSeconds(-1), null /* proposed lease ID */),
                 "acquire a lease with -1 duration");
 
-            TestHelper.ExpectedException(
+            TestHelper.ExpectedException<ArgumentException>(
                 () => leasedBlob.AcquireLease(TimeSpan.FromSeconds(1), null /* proposed lease ID */),
-                "acquire a lease with 1 s duration",
-                HttpStatusCode.BadRequest);
+                "acquire a lease with 1 s duration");
 
-            TestHelper.ExpectedException(
+            TestHelper.ExpectedException<ArgumentException>(
                 () => leasedBlob.AcquireLease(TimeSpan.FromSeconds(14), null /* proposed lease ID */),
-                "acquire a lease that is too short",
-                HttpStatusCode.BadRequest);
+                "acquire a lease that is too short");
 
-            TestHelper.ExpectedException(
+            TestHelper.ExpectedException<ArgumentException>(
                 () => leasedBlob.AcquireLease(TimeSpan.FromSeconds(61), null /* proposed lease ID */),
-                "acquire a lease that is too long",
-                HttpStatusCode.BadRequest);
+                "acquire a lease that is too long");
 
             TestHelper.ExpectedException(
                 () => leasedBlob.AcquireLease(null /* infinite lease */, invalidLeaseId),
@@ -1062,10 +1059,9 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 () => leasedBlob.BreakLease(TimeSpan.FromSeconds(-1)),
                 "break with negative break time");
 
-            TestHelper.ExpectedException(
+            TestHelper.ExpectedException<ArgumentException>(
                 () => leasedBlob.BreakLease(TimeSpan.FromSeconds(61)),
-                "break with too large break time",
-                HttpStatusCode.BadRequest);
+                "break with too large break time");
         }
 
         [TestMethod]

--- a/Test/Common/TestConfigProcess/TestConfigurations.cs
+++ b/Test/Common/TestConfigProcess/TestConfigurations.cs
@@ -23,7 +23,7 @@ namespace Microsoft.WindowsAzure.Storage
 
     public class TestConfigurations
     {
-        public const string DefaultTestConfigFilePath = @"TestConfigurations.xml";
+        public const string DefaultTestConfigFilePath = @"LocalTestConfigurations.xml";
         public string TargetTenantName { get; private set; }
         public IEnumerable<TenantConfiguration> TenantConfigurations { get; private set; }
 

--- a/Test/Common/TestConfigurations.xml
+++ b/Test/Common/TestConfigurations.xml
@@ -13,15 +13,15 @@
   <TenantConfiguration>
     <TenantName>ProductionTenant</TenantName>
     <TenantType>Cloud</TenantType>
-    <AccountName>[ACCOUNT NAME HERE]</AccountName>
-    <AccountKey>[ACCOUNT KEY HERE]</AccountKey>
-    <BlobServiceEndpoint>http://[ACCOUNT].blob.core.windows.net</BlobServiceEndpoint>
-    <QueueServiceEndpoint>http://[ACCOUNT].queue.core.windows.net</QueueServiceEndpoint>
-    <TableServiceEndpoint>http://[ACCOUNT].table.core.windows.net</TableServiceEndpoint>
-    <FileServiceEndpoint>http://[ACCOUNT].file.core.windows.net</FileServiceEndpoint>
-    <BlobServiceSecondaryEndpoint>http://[ACCOUNT]-secondary.blob.core.windows.net</BlobServiceSecondaryEndpoint>
-    <QueueServiceSecondaryEndpoint>http://[ACCOUNT]-secondary.queue.core.windows.net</QueueServiceSecondaryEndpoint>
-    <TableServiceSecondaryEndpoint>http://[ACCOUNT]-secondary.table.core.windows.net</TableServiceSecondaryEndpoint>
+    <AccountName>wassdktesting</AccountName>
+    <AccountKey>DVWWqT1/0ji/uIOL6yKINT0o8yDByUA2H15VfdJqzWDzHdUgxQ4mZdB2J/B0gXJ9LXeaeX0ZTxcQEAcd3nMkpA==</AccountKey>
+    <BlobServiceEndpoint>http://wassdktesting.blob.core.windows.net</BlobServiceEndpoint>
+    <QueueServiceEndpoint>http://wassdktesting.queue.core.windows.net</QueueServiceEndpoint>
+    <TableServiceEndpoint>http://wassdktesting.table.core.windows.net</TableServiceEndpoint>
+    <FileServiceEndpoint>http://wassdktesting.file.core.windows.net</FileServiceEndpoint>
+    <BlobServiceSecondaryEndpoint>http://wassdktesting-secondary.blob.core.windows.net</BlobServiceSecondaryEndpoint>
+    <QueueServiceSecondaryEndpoint>http://wassdktesting-secondary.queue.core.windows.net</QueueServiceSecondaryEndpoint>
+    <TableServiceSecondaryEndpoint>http://wassdktesting-secondary.table.core.windows.net</TableServiceSecondaryEndpoint>
   </TenantConfiguration>
 </TenantConfigurations>
 </TestConfigurations>

--- a/Test/Common/TestConfigurations.xml
+++ b/Test/Common/TestConfigurations.xml
@@ -13,15 +13,15 @@
   <TenantConfiguration>
     <TenantName>ProductionTenant</TenantName>
     <TenantType>Cloud</TenantType>
-    <AccountName>wassdktesting</AccountName>
-    <AccountKey>DVWWqT1/0ji/uIOL6yKINT0o8yDByUA2H15VfdJqzWDzHdUgxQ4mZdB2J/B0gXJ9LXeaeX0ZTxcQEAcd3nMkpA==</AccountKey>
-    <BlobServiceEndpoint>http://wassdktesting.blob.core.windows.net</BlobServiceEndpoint>
-    <QueueServiceEndpoint>http://wassdktesting.queue.core.windows.net</QueueServiceEndpoint>
-    <TableServiceEndpoint>http://wassdktesting.table.core.windows.net</TableServiceEndpoint>
-    <FileServiceEndpoint>http://wassdktesting.file.core.windows.net</FileServiceEndpoint>
-    <BlobServiceSecondaryEndpoint>http://wassdktesting-secondary.blob.core.windows.net</BlobServiceSecondaryEndpoint>
-    <QueueServiceSecondaryEndpoint>http://wassdktesting-secondary.queue.core.windows.net</QueueServiceSecondaryEndpoint>
-    <TableServiceSecondaryEndpoint>http://wassdktesting-secondary.table.core.windows.net</TableServiceSecondaryEndpoint>
+    <AccountName>[ACCOUNT NAME HERE]</AccountName>
+    <AccountKey>[ACCOUNT KEY HERE]</AccountKey>
+    <BlobServiceEndpoint>http://[ACCOUNT].blob.core.windows.net</BlobServiceEndpoint>
+    <QueueServiceEndpoint>http://[ACCOUNT].queue.core.windows.net</QueueServiceEndpoint>
+    <TableServiceEndpoint>http://[ACCOUNT].table.core.windows.net</TableServiceEndpoint>
+    <FileServiceEndpoint>http://[ACCOUNT].file.core.windows.net</FileServiceEndpoint>
+    <BlobServiceSecondaryEndpoint>http://[ACCOUNT]-secondary.blob.core.windows.net</BlobServiceSecondaryEndpoint>
+    <QueueServiceSecondaryEndpoint>http://[ACCOUNT]-secondary.queue.core.windows.net</QueueServiceSecondaryEndpoint>
+    <TableServiceSecondaryEndpoint>http://[ACCOUNT]-secondary.table.core.windows.net</TableServiceSecondaryEndpoint>
   </TenantConfiguration>
 </TenantConfigurations>
 </TestConfigurations>

--- a/Test/WindowsRuntime/Blob/LeaseTests.cs
+++ b/Test/WindowsRuntime/Blob/LeaseTests.cs
@@ -570,20 +570,20 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 async () => await leasedBlob.AcquireLeaseAsync(TimeSpan.FromSeconds(-1), null /* proposed lease ID */),
                 "acquire a lease with -1 duration");
 
-            await TestHelper.ExpectedExceptionAsync(
-                async () => await leasedBlob.AcquireLeaseAsync(TimeSpan.FromSeconds(1), null /* proposed lease ID */, null, null, operationContext),
+            await TestHelper.ExpectedExceptionAsync<ArgumentException>(
+                async () => await leasedBlob.AcquireLeaseAsync(TimeSpan.FromSeconds(1), null /* proposed lease ID */),
                 operationContext,
                 "acquire a lease with 1 s duration",
                 HttpStatusCode.BadRequest);
 
-            await TestHelper.ExpectedExceptionAsync(
-                async () => await leasedBlob.AcquireLeaseAsync(TimeSpan.FromSeconds(14), null /* proposed lease ID */, null, null, operationContext),
+            await TestHelper.ExpectedExceptionAsync<ArgumentException>(
+                async () => await leasedBlob.AcquireLeaseAsync(TimeSpan.FromSeconds(14), null /* proposed lease ID */),
                 operationContext,
                 "acquire a lease that is too short",
                 HttpStatusCode.BadRequest);
 
-            await TestHelper.ExpectedExceptionAsync(
-                async () => await leasedBlob.AcquireLeaseAsync(TimeSpan.FromSeconds(61), null /* proposed lease ID */, null, null, operationContext),
+            await TestHelper.ExpectedExceptionAsync<ArgumentException>(
+                async () => await leasedBlob.AcquireLeaseAsync(TimeSpan.FromSeconds(61), null /* proposed lease ID */),
                 operationContext,
                 "acquire a lease that is too long",
                 HttpStatusCode.BadRequest);
@@ -635,7 +635,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 async () => await leasedBlob.BreakLeaseAsync(TimeSpan.FromSeconds(-1), null, null, operationContext),
                 "break with negative break time");
 
-            await TestHelper.ExpectedExceptionAsync(
+            await TestHelper.ExpectedExceptionAsync<ArgumentException>(
                 async () => await leasedBlob.BreakLeaseAsync(TimeSpan.FromSeconds(61), null, null, operationContext),
                 operationContext,
                 "break with too large break time",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Changes in 6.2.2-preview :
 
 - All: Fixed bug with CoreCLR UserAgent string.
+- Blobs: Fixed boundary checks for lease durations to be in line with REST endpointsf
 
 Changes in 6.2.0 :
 


### PR DESCRIPTION
This addresses #237 

Users will be able to find, in the README.md, how to create and name a local copy of the TestConfigurations.xml file that will then be used by test runs as the source for the Azure Storage container's credentials. The LocalTestConfigurations.xml file that they will create and enter their credentials into is part of the .gitignore so that it will not make it into repos.