### PR TITLE
[.Net][Dec15 Support][CoreCLR RTM] Server-side Encryption, CoreCLR RT…

### DIFF
--- a/BuildAspNetK.cmd
+++ b/BuildAspNetK.cmd
@@ -1,5 +1,5 @@
 pushd %~dp0
-call Tools\nuget3.4.exe install Microsoft.NETCore.Runtime.CoreCLR -Version 1.0.2-rc2-24027 -Prerelease
+call Tools\nuget3.4.exe install Microsoft.NETCore.Runtime.CoreCLR -Version 1.0.3
 call dotnet restore
 cd Lib\AspNet\Microsoft.WindowsAzure.Storage
 call dotnet build --configuration release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ For the CoreCLR solution, you can open the project using the AspNet_k.sln soluti
 ## Tests
 
 ### Configuration
-The only step to configure testing is to add a TestConfiguration.xml to the Test/Common/ folder. You should insert your storage account information into the file using [this](Test/Common/TestConfigurationsTemplate.xml) as a template.
+The only step to configure testing is to add a TestConfigurations.xml to the Test/Common/ folder. You should insert your storage account information into the file using [this](Test/Common/TestConfigurationsTemplate.xml) as a template.
 
 ### Running
 To actually run tests, right click the individual test or test class in the Test Explorer panel.

--- a/Lib/AspNet/Microsoft.WindowsAzure.Storage/AssemblyInfo.cs
+++ b/Lib/AspNet/Microsoft.WindowsAzure.Storage/AssemblyInfo.cs
@@ -33,9 +33,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
-[assembly: AssemblyInformationalVersion("7.0.2.0-preview")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
+[assembly: AssemblyInformationalVersion("7.1.1.0-preview")]
 
 [assembly: InternalsVisibleTo(
     "Microsoft.WindowsAzure.Storage.Test, PublicKey=" +

--- a/Lib/AspNet/Microsoft.WindowsAzure.Storage/WindowsAzure.StorageK.nuspec
+++ b/Lib/AspNet/Microsoft.WindowsAzure.Storage/WindowsAzure.StorageK.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.8.3">
     <id>WindowsAzure.Storage</id>
-    <version>7.0.2-preview</version>
+    <version>7.1.1-preview</version>
     <title>Windows Azure Storage</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -18,10 +18,10 @@
     <summary>A client library for working with Microsoft Azure storage services including blobs, files, tables, and queues.</summary>
     <tags>Microsoft, Azure, Storage, Table, Blob, File, Queue, Scalable, windowsazureofficial</tags>
     <dependencies>
-      <group targetFramework=".NETStandardApp1.5">
-        <dependency id="NETStandard.Library" version="1.5.0-rc2-24027" />
-        <dependency id="System.Dynamic.Runtime" version="4.0.11-rc2-24027" />
-        <dependency id="System.Security.Cryptography.Algorithms" version="4.1.0-rc2-24027" />
+      <group targetFramework=".netstandard1.6">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="System.Dynamic.Runtime" version="4.0.11" />
+        <dependency id="System.Security.Cryptography.Algorithms" version="4.2.0" /> 
         <dependency id="Microsoft.Data.OData" version="5.6.4" />
         <dependency id="Microsoft.Data.Services.Client" version="5.6.4" />
         <dependency id="System.Spatial" version="5.6.4" />

--- a/Lib/AspNet/Microsoft.WindowsAzure.Storage/project.json
+++ b/Lib/AspNet/Microsoft.WindowsAzure.Storage/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "7.0.2.0",
+    "version": "7.1.1.0",
     "authors": [ "Microsoft Corporation" ],
     "description": "Azure Storage SDK for CoreCLR Preview",
     "dependencies": {
@@ -10,11 +10,11 @@
     },
 
     "frameworks": {
-        "netstandard1.5": {
+        "netstandard1.6": {
             "dependencies": {
-                "NETStandard.Library": "1.5.0-rc2-24027",
-                "System.Dynamic.Runtime": "4.0.11-rc2-24027",
-                "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24027"
+                "NETStandard.Library": "1.6.0",
+                "System.Dynamic.Runtime": "4.0.11",
+                "System.Security.Cryptography.Algorithms": "4.2.0"
             },
             "imports": [
                 "dnxcore50",
@@ -25,7 +25,7 @@
             "dependencies": {
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.0-rc2-3002702"
+                    "version": "1.0.0"
                 }
             },
             "imports": [

--- a/Lib/ClassLibraryCommon/Blob/BlobEncryptionPolicy.cs
+++ b/Lib/ClassLibraryCommon/Blob/BlobEncryptionPolicy.cs
@@ -121,16 +121,16 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                     // locally. No service call is made.
                     if (this.KeyResolver != null)
                     {
-                        IKey keyEncryptionKey = this.KeyResolver.ResolveKeyAsync(encryptionData.WrappedContentKey.KeyId, CancellationToken.None).Result;
+                        IKey keyEncryptionKey = CommonUtility.RunWithoutSynchronizationContext(() => this.KeyResolver.ResolveKeyAsync(encryptionData.WrappedContentKey.KeyId, CancellationToken.None).Result);
 
                         CommonUtility.AssertNotNull("KeyEncryptionKey", keyEncryptionKey);
-                        contentEncryptionKey = keyEncryptionKey.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result;
+                        contentEncryptionKey = CommonUtility.RunWithoutSynchronizationContext(() => keyEncryptionKey.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result);
                     }
                     else
                     {
                         if (this.Key.Kid == encryptionData.WrappedContentKey.KeyId)
                         {
-                            contentEncryptionKey = this.Key.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result;
+                            contentEncryptionKey = CommonUtility.RunWithoutSynchronizationContext(() => this.Key.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result);
                         }
                         else
                         {
@@ -237,7 +237,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 encryptionData.EncryptionAgent = new EncryptionAgent(Constants.EncryptionConstants.EncryptionProtocolV1, EncryptionAlgorithm.AES_CBC_256);
 
                 // Wrap always happens locally, irrespective of local or cloud key. So it is ok to call it synchronously.
-                Tuple<byte[], string> wrappedKey = this.Key.WrapKeyAsync(aesProvider.Key, null /* algorithm */, CancellationToken.None).Result;
+                Tuple<byte[], string> wrappedKey = CommonUtility.RunWithoutSynchronizationContext(() => this.Key.WrapKeyAsync(aesProvider.Key, null /* algorithm */, CancellationToken.None).Result);
                 encryptionData.WrappedContentKey = new WrappedKey(this.Key.Kid, wrappedKey.Item1, wrappedKey.Item2);
                 encryptionData.EncryptionMode = this.EncryptionMode.ToString();
                 encryptionData.KeyWrappingMetadata = new Dictionary<string, string>();

--- a/Lib/ClassLibraryCommon/Blob/CloudAppendBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudAppendBlob.cs
@@ -2813,6 +2813,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             {
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, NullType.Value, cmd, ex);
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, false);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
                 this.Properties.Length = 0;
                 return NullType.Value;
             };
@@ -2858,6 +2859,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, appendOffset, cmd, ex);
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, false);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
                 return appendOffset;
             };
 

--- a/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
@@ -3065,6 +3065,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             {
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, NullType.Value, cmd, ex);
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(blobAttributes, resp, false);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
                 return NullType.Value;
             };
 
@@ -3479,6 +3480,17 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             CommonUtility.AssertNotNull("source", source);
             return source.ServiceClient.Credentials.TransformUri(source.SnapshotQualifiedUri);
+        }
+
+        /// <summary>
+        /// Parses the server request encrypted response header.
+        /// </summary>
+        /// <param name="response">Response to be parsed.</param>
+        /// <returns><c>true</c> if write content was encrypted by service or <c>false</c> if not.</returns>
+        internal static bool ParseServerRequestEncrypted(HttpWebResponse response)
+        {
+            string requestEncrypted = response.Headers[Constants.HeaderConstants.ServerRequestEncrypted];
+            return string.Equals(requestEncrypted, Constants.HeaderConstants.TrueHeader, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Lib/ClassLibraryCommon/Blob/CloudBlockBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlockBlob.cs
@@ -2338,6 +2338,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             {
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, NullType.Value, cmd, ex);
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, false);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
                 this.Properties.Length = putCmd.SendStreamLength.Value;
                 return NullType.Value;
             };
@@ -2374,7 +2375,12 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 }
             };
             putCmd.SignRequest = this.ServiceClient.AuthenticationHandler.SignRequest;
-            putCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, NullType.Value, cmd, ex);
+            putCmd.PreProcessResponse = (cmd, resp, ex, ctx) =>
+            {
+                HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, NullType.Value, cmd, ex);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
+                return NullType.Value;
+            };
 
             return putCmd;
         }
@@ -2423,6 +2429,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             {
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, NullType.Value, cmd, ex);
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, false);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
                 this.Properties.Length = -1;
                 return NullType.Value;
             };

--- a/Lib/ClassLibraryCommon/Blob/CloudPageBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudPageBlob.cs
@@ -2325,6 +2325,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             {
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, NullType.Value, cmd, ex);
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, false);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
                 this.Properties.Length = sizeInBytes;
                 return NullType.Value;
             };
@@ -2489,6 +2490,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             {
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.Created, resp, NullType.Value, cmd, ex);
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, false);
+                cmd.CurrentResult.IsRequestServerEncrypted = CloudBlob.ParseServerRequestEncrypted(resp);
                 return NullType.Value;
             };
 

--- a/Lib/ClassLibraryCommon/Core/Util/AsyncExtensions.cs
+++ b/Lib/ClassLibraryCommon/Core/Util/AsyncExtensions.cs
@@ -291,6 +291,41 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
 
             return taskCompletionSource.Task;
         }
+        internal static Task TaskFromVoidApm<T1, T2, T3, T4, T5, T6, T7, T8>(Func<T1, T2, T3, T4, T5, T6, T7, T8, AsyncCallback, object, ICancellableAsyncResult> beginMethod, Action<IAsyncResult> endMethod, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
+        {
+            TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                taskCompletionSource.TrySetCanceled();
+            }
+            else
+            {
+                CancellableOperationBase cancellableOperation;
+                CancellationTokenRegistration? registration = RegisterCancellationToken(cancellationToken, out cancellableOperation);
+                ICancellableAsyncResult result = beginMethod(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CreateCallbackVoid(taskCompletionSource, registration, endMethod), null /* state */);
+                AssignCancellableOperation(cancellableOperation, result, cancellationToken);
+            }
+
+            return taskCompletionSource.Task;
+        }
+
+        internal static Task TaskFromVoidApm<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, AsyncCallback, object, ICancellableAsyncResult> beginMethod, Action<IAsyncResult> endMethod, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, CancellationToken cancellationToken)
+        {
+            TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                taskCompletionSource.TrySetCanceled();
+            }
+            else
+            {
+                CancellableOperationBase cancellableOperation;
+                CancellationTokenRegistration? registration = RegisterCancellationToken(cancellationToken, out cancellableOperation);
+                ICancellableAsyncResult result = beginMethod(arg1, arg2, arg3, arg4, arg5, arg6, arg7,arg8, arg9, CreateCallbackVoid(taskCompletionSource, registration, endMethod), null /* state */);
+                AssignCancellableOperation(cancellableOperation, result, cancellationToken);
+            }
+
+            return taskCompletionSource.Task;
+        }
 
         internal static Task<TResult> TaskFromApm<TResult>(Func<AsyncCallback, object, ICancellableAsyncResult> beginMethod, Func<IAsyncResult, TResult> endMethod, CancellationToken cancellationToken)
         {
@@ -430,6 +465,40 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
                 CancellableOperationBase cancellableOperation;
                 CancellationTokenRegistration? registration = RegisterCancellationToken(cancellationToken, out cancellableOperation);
                 ICancellableAsyncResult result = beginMethod(arg1, arg2, arg3, arg4, arg5, arg6, arg7, CreateCallback(taskCompletionSource, registration, endMethod), null /* state */);
+                AssignCancellableOperation(cancellableOperation, result, cancellationToken);
+            }
+
+            return taskCompletionSource.Task;
+        }
+        internal static Task<TResult> TaskFromApm<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, AsyncCallback, object, ICancellableAsyncResult> beginMethod, Func<IAsyncResult, TResult> endMethod, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, CancellationToken cancellationToken)
+        {
+            TaskCompletionSource<TResult> taskCompletionSource = new TaskCompletionSource<TResult>();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                taskCompletionSource.TrySetCanceled();
+            }
+            else
+            {
+                CancellableOperationBase cancellableOperation;
+                CancellationTokenRegistration? registration = RegisterCancellationToken(cancellationToken, out cancellableOperation);
+                ICancellableAsyncResult result = beginMethod(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, CreateCallback(taskCompletionSource, registration, endMethod), null /* state */);
+                AssignCancellableOperation(cancellableOperation, result, cancellationToken);
+            }
+
+            return taskCompletionSource.Task;
+        }
+        internal static Task<TResult> TaskFromApm<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, AsyncCallback, object, ICancellableAsyncResult> beginMethod, Func<IAsyncResult, TResult> endMethod, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, CancellationToken cancellationToken)
+        {
+            TaskCompletionSource<TResult> taskCompletionSource = new TaskCompletionSource<TResult>();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                taskCompletionSource.TrySetCanceled();
+            }
+            else
+            {
+                CancellableOperationBase cancellableOperation;
+                CancellationTokenRegistration? registration = RegisterCancellationToken(cancellationToken, out cancellableOperation);
+                ICancellableAsyncResult result = beginMethod(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, CreateCallback(taskCompletionSource, registration, endMethod), null /* state */);
                 AssignCancellableOperation(cancellableOperation, result, cancellationToken);
             }
 

--- a/Lib/ClassLibraryCommon/Queue/QueueEncryptionPolicy.cs
+++ b/Lib/ClassLibraryCommon/Queue/QueueEncryptionPolicy.cs
@@ -88,7 +88,7 @@ namespace Microsoft.WindowsAzure.Storage.Queue
                 encryptionData.ContentEncryptionIV = myAes.IV;
 
                 // Wrap always happens locally, irrespective of local or cloud key. So it is ok to call it synchronously.
-                Tuple<byte[], string> wrappedKey = this.Key.WrapKeyAsync(myAes.Key, null /* algorithm */, CancellationToken.None).Result;
+                Tuple<byte[], string> wrappedKey = CommonUtility.RunWithoutSynchronizationContext(() => this.Key.WrapKeyAsync(myAes.Key, null /* algorithm */, CancellationToken.None).Result);
                 encryptionData.WrappedContentKey = new WrappedKey(this.Key.Kid, wrappedKey.Item1, wrappedKey.Item2);
 
                 using (ICryptoTransform encryptor = myAes.CreateEncryptor())
@@ -149,16 +149,16 @@ namespace Microsoft.WindowsAzure.Storage.Queue
                     // locally. No service call is made.
                     if (this.KeyResolver != null)
                     {
-                        IKey keyEncryptionKey = this.KeyResolver.ResolveKeyAsync(encryptionData.WrappedContentKey.KeyId, CancellationToken.None).Result;
+                        IKey keyEncryptionKey = CommonUtility.RunWithoutSynchronizationContext(() => this.KeyResolver.ResolveKeyAsync(encryptionData.WrappedContentKey.KeyId, CancellationToken.None).Result);
 
                         CommonUtility.AssertNotNull("keyEncryptionKey", keyEncryptionKey);
-                        contentEncryptionKey = keyEncryptionKey.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result;
+                        contentEncryptionKey = CommonUtility.RunWithoutSynchronizationContext(() => keyEncryptionKey.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result);
                     }
                     else
                     {
                         if (this.Key.Kid == encryptionData.WrappedContentKey.KeyId)
                         {
-                            contentEncryptionKey = this.Key.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result;
+                            contentEncryptionKey = CommonUtility.RunWithoutSynchronizationContext(() => this.Key.UnwrapKeyAsync(encryptionData.WrappedContentKey.EncryptedKey, encryptionData.WrappedContentKey.Algorithm, CancellationToken.None).Result);
                         }
                         else
                         {

--- a/Lib/Common/Blob/BlobProperties.cs
+++ b/Lib/Common/Blob/BlobProperties.cs
@@ -54,6 +54,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             this.LastModified = other.LastModified;
             this.PageBlobSequenceNumber = other.PageBlobSequenceNumber;
             this.AppendBlobCommittedBlockCount = other.AppendBlobCommittedBlockCount;
+            this.IsServerEncrypted = other.IsServerEncrypted;
         }
 
         /// <summary>
@@ -157,5 +158,10 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// </summary>
         /// <value>An integer containing the number of committed blocks.</value>
         public int? AppendBlobCommittedBlockCount { get; internal set; }
+
+        /// <summary>
+        /// Gets the blob's server-side encryption state.
+        /// </summary>
+        public bool IsServerEncrypted { get; internal set; }
     }
 }

--- a/Lib/Common/Core/Util/CommonUtility.cs
+++ b/Lib/Common/Core/Util/CommonUtility.cs
@@ -27,6 +27,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Threading;
     using System.Xml;
 
 #if WINDOWS_DESKTOP 
@@ -377,5 +378,37 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
 #endif
         }
 #endif
+
+        // TODO: When we move to .NET 4.5, we may be able to get rid of this method, or at least reduce our reliance upon it.
+        // The ideal solution is to use async either everywhere or nowhere throughout a call to the Storage library, but this may
+        // not be possible (KeyVault only exposes async APIs, and doesn't use ConfigureAwait(false), for example).
+        // Blog post discussing this is here: http://blogs.msdn.com/b/pfxteam/archive/2012/04/13/10293638.aspx
+        internal static void RunWithoutSynchronizationContext(Action actionToRun)
+        {
+            SynchronizationContext oldContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                actionToRun();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
+        }
+
+        internal static T RunWithoutSynchronizationContext<T>(Func<T> actionToRun)
+        {
+            SynchronizationContext oldContext = SynchronizationContext.Current;
+            try
+            {
+                SynchronizationContext.SetSynchronizationContext(null);
+                return actionToRun();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(oldContext);
+            }
+        }
     }
 }

--- a/Lib/Common/RequestResult.cs
+++ b/Lib/Common/RequestResult.cs
@@ -100,6 +100,11 @@ namespace Microsoft.WindowsAzure.Storage
         public StorageExtendedErrorInformation ExtendedErrorInformation { get; internal set; }
 
         /// <summary>
+        /// Gets whether or not the data for a write operation is encrypted server-side.
+        /// </summary>
+        public bool IsRequestServerEncrypted { get; internal set; }
+
+        /// <summary>
         /// Gets or sets the exception.
         /// </summary>
         /// <value>An <see cref="System.Exception"/> object.</value>

--- a/Lib/Common/Shared/Protocol/Constants.cs
+++ b/Lib/Common/Shared/Protocol/Constants.cs
@@ -323,6 +323,11 @@ namespace Microsoft.WindowsAzure.Storage.Shared.Protocol
         public const string LastModifiedElement = "Last-Modified";
 
         /// <summary>
+        /// XML element for the server encryption status.
+        /// </summary>
+        public const string ServerEncryptionElement = "ServerEncrypted";
+
+        /// <summary>
         /// XML element for the Url.
         /// </summary>
         public const string UrlElement = "Url";
@@ -772,9 +777,9 @@ namespace Microsoft.WindowsAzure.Storage.Shared.Protocol
             /// Specifies the value to use for UserAgent header.
             /// </summary>
 #if ASPNET_K || PORTABLE
-            public const string UserAgentProductVersion = "7.0.2-preview";
+            public const string UserAgentProductVersion = "7.1.1-preview";
 #else
-            public const string UserAgentProductVersion = "7.0.2";
+            public const string UserAgentProductVersion = "7.1.0";
 #endif 
 
             /// <summary>
@@ -821,6 +826,16 @@ namespace Microsoft.WindowsAzure.Storage.Shared.Protocol
             /// Header that specifies the ETag value for the resource.
             /// </summary>
             public const string EtagHeader = "ETag";
+
+            /// <summary>
+            /// Header that specifies if a resourse is fully encrypted server-side.
+            /// </summary>
+            public const string ServerEncrypted = PrefixForStorageHeader + "server-encrypted";
+
+            /// <summary>
+            /// Header that acknowledges the data used for write operation is encrypted server-side.
+            /// </summary>
+            public const string ServerRequestEncrypted = PrefixForStorageHeader + "request-server-encrypted";
 
             /// <summary>
             /// Header for data ranges.
@@ -1056,7 +1071,7 @@ namespace Microsoft.WindowsAzure.Storage.Shared.Protocol
             /// Current storage version header value.
             /// Every time this version changes, assembly version needs to be updated as well.
             /// </summary>
-            public const string TargetStorageVersion = "2015-07-08";
+            public const string TargetStorageVersion = "2015-12-11";
 
             /// <summary>
             /// Specifies the file type.

--- a/Lib/Common/StorageException.cs
+++ b/Lib/Common/StorageException.cs
@@ -206,7 +206,7 @@ namespace Microsoft.WindowsAzure.Storage
                 if (response != null)
                 {
                     StorageException.PopulateRequestResult(reqResult, response);
-                    reqResult.ExtendedErrorInformation = StorageExtendedErrorInformation.ReadFromStream(response.Content.ReadAsStreamAsync().Result);
+                    reqResult.ExtendedErrorInformation = CommonUtility.RunWithoutSynchronizationContext(() => StorageExtendedErrorInformation.ReadFromStream(response.Content.ReadAsStreamAsync().Result));
                 }
             }
             catch (Exception)

--- a/Lib/Common/Table/TableEntity.cs
+++ b/Lib/Common/Table/TableEntity.cs
@@ -44,7 +44,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
     [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = "Reviewed.")]
     [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = "Reviewed.")]
     [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1001:CommasMustBeSpacedCorrectly", Justification = "Reviewed.")]
-    public class TableEntity : ITableEntity
+    public class TableEntity : ITableEntity 
     {
 #if WINDOWS_DESKTOP && !WINDOWS_PHONE
         static TableEntity()
@@ -147,7 +147,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
 #if WINDOWS_RT || PORTABLE
             IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetRuntimeProperties();
 #elif ASPNET_K
-            IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetTypeInfo().DeclaredProperties;
+            IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetTypeInfo().GetProperties();
 
 #else
             IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetProperties();
@@ -304,7 +304,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
 #if WINDOWS_RT || PORTABLE
             IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetRuntimeProperties();
 #elif ASPNET_K
-            IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetTypeInfo().DeclaredProperties;
+            IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetTypeInfo().GetProperties();
 #else
             IEnumerable<PropertyInfo> objectProperties = entity.GetType().GetProperties();
 #endif
@@ -317,7 +317,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
                 }
 
                 EntityProperty newProperty = EntityProperty.CreateEntityPropertyFromObject(property.GetValue(entity, null), property.PropertyType);
-
+                
                 // Add the fact that this property needs to be encrypted
                 // properties with [EncryptAttribute]
 #if !(WINDOWS_RT || ASPNET_K || PORTABLE)

--- a/Lib/Portable/Properties/AssemblyInfo.cs
+++ b/Lib/Portable/Properties/AssemblyInfo.cs
@@ -26,6 +26,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
-[assembly: AssemblyInformationalVersion("7.0.2.0-preview")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
+[assembly: AssemblyInformationalVersion("7.1.1.0-preview")]

--- a/Lib/WindowsDesktop/Properties/AssemblyInfo.cs
+++ b/Lib/WindowsDesktop/Properties/AssemblyInfo.cs
@@ -34,8 +34,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 
 #if SIGN
 [assembly: InternalsVisibleTo(

--- a/Lib/WindowsDesktop/WindowsAzure.Storage.nuspec
+++ b/Lib/WindowsDesktop/WindowsAzure.Storage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>WindowsAzure.Storage</id>
-    <version>7.0.0</version>
+    <version>7.1.0</version>
     <title>Windows Azure Storage</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/Lib/WindowsPhone/Properties/AssemblyInfo.cs
+++ b/Lib/WindowsPhone/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Resources;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 
 #if SIGN

--- a/Lib/WindowsPhoneRT/Properties/AssemblyInfo.cs
+++ b/Lib/WindowsPhoneRT/Properties/AssemblyInfo.cs
@@ -24,8 +24,8 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 [assembly: ComVisible(false)]
 

--- a/Lib/WindowsRuntime/Auth/Protocol/StorageAuthenticationHttpHandler.cs
+++ b/Lib/WindowsRuntime/Auth/Protocol/StorageAuthenticationHttpHandler.cs
@@ -22,6 +22,7 @@ namespace Microsoft.WindowsAzure.Storage.Auth.Protocol
     using Microsoft.WindowsAzure.Storage.Core.Util;
     using Microsoft.WindowsAzure.Storage.Shared.Protocol;
     using System;
+    using System.Net;
     using System.Globalization;
     using System.Net.Http;
     using System.Net.Http.Headers;
@@ -30,7 +31,15 @@ namespace Microsoft.WindowsAzure.Storage.Auth.Protocol
 
     internal sealed partial class StorageAuthenticationHttpHandler : HttpClientHandler
     {
-        private static Lazy<StorageAuthenticationHttpHandler> instance = new Lazy<StorageAuthenticationHttpHandler>(() => new StorageAuthenticationHttpHandler());
+        private StorageAuthenticationHttpHandler()
+        {
+#if ASPNET_K
+            this.AutomaticDecompression = DecompressionMethods.None;
+#endif
+        }
+
+        private static Lazy<StorageAuthenticationHttpHandler> instance =
+            new Lazy<StorageAuthenticationHttpHandler>(() => new StorageAuthenticationHttpHandler());
 
         public static StorageAuthenticationHttpHandler Instance
         {

--- a/Lib/WindowsRuntime/Shared/Protocol/HttpClientFactory.cs
+++ b/Lib/WindowsRuntime/Shared/Protocol/HttpClientFactory.cs
@@ -21,6 +21,7 @@ namespace Microsoft.WindowsAzure.Storage.Shared.Protocol
     using System;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Threading;
 
     internal static class HttpClientFactory
     {
@@ -33,6 +34,7 @@ namespace Microsoft.WindowsAzure.Storage.Shared.Protocol
                         newClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Constants.HeaderConstants.UserAgentProductName, Constants.HeaderConstants.UserAgentProductVersion));
                         newClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Constants.HeaderConstants.UserAgentComment));
                         newClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.HeaderConstants.StorageVersionHeader, Constants.HeaderConstants.TargetStorageVersion);
+                        newClient.Timeout = Timeout.InfiniteTimeSpan;
 
                         return newClient;
                     });

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ complete Azure SDK, please see the [Microsoft Azure .NET Developer Center](http:
 - Blobs
     - Create/Read/Update/Delete Blobs
 - Files
-	- Create/Update/Delete Directories
-	- Create/Read/Update/Delete Files
+    - Create/Update/Delete Directories
+    - Create/Read/Update/Delete Files
 - Queues
     - Create/Delete Queues
     - Insert/Peek Queue Messages
     - Advanced Queue Operations
-	
+
 ## Getting Started
 
 The complete Microsoft Azure SDK can be downloaded from the [Microsoft Azure Downloads Page](http://azure.microsoft.com/en-us/downloads/?sdk=net) and ships with support for building deployment packages, integrating with tooling, rich command line tooling, and more.
@@ -34,7 +34,7 @@ For the best development experience, developers should use the official Microsof
 - .NET Framework 4.0: As of October 2012, Storage Client Libraries for .NET supports primarily the desktop .NET Framework 4 release and above.
 - Windows 8 and 8.1 for Windows Store app development: Storage Client Libraries are available for Windows Store applications.
 - Windows Phone 8 and 8.1 app development: Storage Client Libraries are available for Windows Phone applications including Universal applications.
-- CoreCLR (rc2): Storage Client Libraries for .NET are available to support CoreCLR application development. This support is currently in preview. 
+- CoreCLR RTM: Storage Client Libraries for .NET are available to support CoreCLR application development. This support is currently in preview. 
 - Portable Class Library Profile 111: Storage Client Libraries are available to support building PCL Profile 111 applications, as well as for Xamarin application development. This support is currently in preview.
  
 ## Requirements
@@ -51,13 +51,13 @@ For the best development experience, developers should use the official Microsof
 ## Use with the Azure Storage Emulator
 
 - The Client Library uses a particular Storage Service version. In order to use the Storage Client Library with the Storage Emulator, a corresponding minimum version of the Azure Storage Emulator must be used. Older versions of the Storage Emulator do not have the necessary code to successfully respond to new requests.
-- Currently, the minimum version of the Azure Storage Emulator needed for this library is 4.3. If you encounter a `VersionNotSupportedByEmulator` (400 Bad Request) error, please [update the Storage Emulator.](https://azure.microsoft.com/en-us/downloads/)
+- Currently, the minimum version of the Azure Storage Emulator needed for this library is 4.4. If you encounter a `VersionNotSupportedByEmulator` (400 Bad Request) error, please [update the Storage Emulator.](https://azure.microsoft.com/en-us/downloads/)
 
 ## Download & Install
 
 The Storage Client Library ships with the Microsoft Azure SDK for .NET and also on NuGet. You'll find the latest version and hotfixes on NuGet via the `WindowsAzure.Storage` package. 
 
-This version of the Storage Client Library ships with the storage version 2015-07-08.
+This version of the Storage Client Library ships with the storage version 2015-12-11.
 
 ### Via Git
 
@@ -88,6 +88,16 @@ The specific ODataLib packages are:
 - [Microsoft.Data.OData](http://nuget.org/packages/Microsoft.Data.OData/)
 - [Microsoft.Data.Edm](http://nuget.org/packages/Microsoft.Data.Edm/)
 - [System.Spatial](http://nuget.org/packages/System.Spatial)
+
+> Note:
+> The ODataLib packages currently do not support "netstandard1.6" or "netcoreapp1.0" frameworks in projects depending on the current relase of Dotnet CoreCLR. Thus, you may encounter failures while trying to restore the ODataLib dependencies for one of the targeted frameworks mentioned above. Until the support is added, if you run into this, you can use the imports statement within the framework node of your project.json file to specify to NuGet that it can restore the packages targeting the framework within the "imports" statement as shown below:
+
+```
+  "imports": [
+    "dnxcore50",
+    "portable-net451+win8"
+  ]
+```
 
 ### Newtonsoft Json
 
@@ -167,6 +177,8 @@ We gladly accept community contributions.
 - Issues: Please report bugs using the Issues section of GitHub
 - Forums: Interact with the development teams on StackOverflow or the Microsoft Azure Forums
 - Source Code Contributions: Please see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute code.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 For general suggestions about Microsoft Azure please use our [UserVoice forum](http://feedback.azure.com/forums/34192--general-feedback).
 

--- a/Test/AspNet/Microsoft.WindowsAzure.Storage.Test/project.json
+++ b/Test/AspNet/Microsoft.WindowsAzure.Storage.Test/project.json
@@ -1,11 +1,11 @@
 ﻿{
-    "version": "7.0.2.0",
+    "version": "7.1.1.0",
     "testRunner": "xunit",
 
     "dependencies": {
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-rc2-build10015",
-        "Microsoft.WindowsAzure.Storage": "7.0.2-*",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "Microsoft.WindowsAzure.Storage": "7.1.1.0",
         "XUnitForMsTest": "1.0.0-*"
     },
 
@@ -14,7 +14,7 @@
             "dependencies": {
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.0-rc2-3002702"
+                    "version": "1.0.0"
                 }
             },
             "imports": [

--- a/Test/AspNet/XUnitForMsTest/project.json
+++ b/Test/AspNet/XUnitForMsTest/project.json
@@ -4,7 +4,7 @@
 
     "dependencies": {
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-rc2-build10015"
+        "dotnet-test-xunit": "2.2.0-preview2-build1029"
     },
 
 
@@ -13,7 +13,7 @@
             "dependencies": {
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.0-rc2-3002702"
+                    "version": "1.0.0"
                 }
             },
             "imports": [

--- a/Test/ClassLibraryCommon/Blob/BlobClientEncryptionTests.cs
+++ b/Test/ClassLibraryCommon/Blob/BlobClientEncryptionTests.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------------------------
-// <copyright file="BlobEncryptionTests.cs" company="Microsoft">
+// <copyright file="BlobClientEncryptionTests.cs" company="Microsoft">
 //    Copyright 2013 Microsoft Corporation
 // 
 //    Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
     using System.Threading.Tasks;
 
     [TestClass]
-    public class BlobEncryptionTests : BlobTestBase
+    public class BlobClientEncryptionTests : BlobTestBase
     {
         // Use TestInitialize to run code before running each test 
         [TestInitialize()]

--- a/Test/ClassLibraryCommon/Blob/BlobServerEncryptionTests.cs
+++ b/Test/ClassLibraryCommon/Blob/BlobServerEncryptionTests.cs
@@ -1,0 +1,129 @@
+﻿// -----------------------------------------------------------------------------------------
+// <copyright file="BlobServerEncryptionTests.cs" company="Microsoft">
+//    Copyright 2016 Microsoft Corporation
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// -----------------------------------------------------------------------------------------
+
+namespace Microsoft.WindowsAzure.Storage.Blob
+{
+    using Microsoft.Azure.KeyVault;
+    using Microsoft.Azure.KeyVault.Core;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.WindowsAzure.Storage.Core;
+    using Microsoft.WindowsAzure.Storage.Shared.Protocol;
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Security.Cryptography;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    [TestClass]
+    public class BlobServerEncryptionTests : BlobTestBase
+    {
+        private CloudBlobContainer container;
+        private CloudBlockBlob blob;
+
+        // Use TestInitialize to run code before running each test 
+        [TestInitialize()]
+        public void MyTestInitialize()
+        {
+            if (TestBase.BlobBufferManager != null)
+            {
+                TestBase.BlobBufferManager.OutstandingBufferCount = 0;
+            }
+
+            this.container = GetRandomContainerReference();
+            this.container.CreateIfNotExists();
+            this.blob = this.container.GetBlockBlobReference(BlobTestBase.GetRandomContainerName());
+            this.blob.UploadText("test");
+        }
+
+        // Use TestCleanup to run code after each test has run
+        [TestCleanup()]
+        public void MyTestCleanup()
+        {
+            if (TestBase.BlobBufferManager != null)
+            {
+                Assert.AreEqual(0, TestBase.BlobBufferManager.OutstandingBufferCount);
+            }
+
+            this.container.DeleteIfExists();
+        }
+
+        [TestMethod]
+        [Description("Download encrypted blob attributes.")]
+        [TestCategory(ComponentCategory.Blob)]
+        [TestCategory(TestTypeCategory.UnitTest)]
+        [TestCategory(SmokeTestCategory.NonSmoke)]
+        [TestCategory(TenantTypeCategory.DevStore)]
+        [TestCategory(TenantTypeCategory.DevFabric)]
+        [TestCategory(TenantTypeCategory.Cloud)]
+        public void TestBlobAttributesEncryption()
+        {
+            this.blob.FetchAttributes();
+            Assert.IsTrue(this.blob.Properties.IsServerEncrypted);
+
+            CloudBlockBlob testBlob = this.container.GetBlockBlobReference(this.blob.Name);
+            testBlob.DownloadText();
+            Assert.IsTrue(testBlob.Properties.IsServerEncrypted);
+        }
+
+        [TestMethod]
+        [Description("List encrypted blob(s).")]
+        [TestCategory(ComponentCategory.Blob)]
+        [TestCategory(TestTypeCategory.UnitTest)]
+        [TestCategory(SmokeTestCategory.NonSmoke)]
+        [TestCategory(TenantTypeCategory.DevStore)]
+        [TestCategory(TenantTypeCategory.DevFabric)]
+        [TestCategory(TenantTypeCategory.Cloud)]
+        public void TestListBlobsEncryption()
+        {
+            bool blobFound = false;
+
+            foreach(IListBlobItem b in this.container.ListBlobs()) {
+                CloudBlob blob = (CloudBlob) b;
+                Assert.IsTrue(blob.Properties.IsServerEncrypted);
+                
+                blobFound = true;
+            }
+
+            Assert.IsTrue(blobFound);
+        }
+
+        [TestMethod]
+        [Description("Upload encrypted blob.")]
+        [TestCategory(ComponentCategory.Blob)]
+        [TestCategory(TestTypeCategory.UnitTest)]
+        [TestCategory(SmokeTestCategory.NonSmoke)]
+        [TestCategory(TenantTypeCategory.DevStore)]
+        [TestCategory(TenantTypeCategory.DevFabric)]
+        [TestCategory(TenantTypeCategory.Cloud)]
+        public void TestBlobEncryption()
+        {
+            bool requestFound = false;
+
+            OperationContext ctxt = new OperationContext();
+            ctxt.RequestCompleted += (sender, args) =>
+            {
+                Assert.IsTrue(args.RequestInformation.IsRequestServerEncrypted);
+                requestFound = true;
+            };
+
+            this.blob.UploadText("test", null, null, null, ctxt);
+            Assert.IsTrue(requestFound);
+        }
+    }
+}

--- a/Test/FaultInjection/AzureStorageMangler/StorageConstants.cs
+++ b/Test/FaultInjection/AzureStorageMangler/StorageConstants.cs
@@ -18,7 +18,7 @@
 namespace Microsoft.WindowsAzure.Test.Network
 {
     /// <summary>
-    /// Hholds well-known information about Windows Azure Storage.
+    /// Holds well-known information about Windows Azure Storage.
     /// </summary>
     public static class StorageConstants
     {

--- a/Test/WindowsDesktop/Properties/AssemblyInfo.cs
+++ b/Test/WindowsDesktop/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]

--- a/Test/WindowsPhone/Properties/AssemblyInfo.cs
+++ b/Test/WindowsPhone/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Resources;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]

--- a/Test/WindowsPhone81/Properties/AssemblyInfo.cs
+++ b/Test/WindowsPhone81/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Resources;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]

--- a/Test/WindowsPhoneRT.Test/Properties/AssemblyInfo.cs
+++ b/Test/WindowsPhoneRT.Test/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 [assembly: ComVisible(false)]

--- a/Test/WindowsRuntime/Blob/CloudBlockBlobTest.cs
+++ b/Test/WindowsRuntime/Blob/CloudBlockBlobTest.cs
@@ -244,9 +244,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
                 blob.Properties.CacheControl = "no-transform";
                 blob.Properties.ContentDisposition = "attachment";
-#if !ASPNET_K
                 blob.Properties.ContentEncoding = "gzip";
-#endif
                 blob.Properties.ContentLanguage = "tr,en";
                 blob.Properties.ContentMD5 = "MDAwMDAwMDA=";
                 blob.Properties.ContentType = "text/html";
@@ -258,9 +256,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 await blob2.FetchAttributesAsync();
                 Assert.AreEqual("no-transform", blob2.Properties.CacheControl);
                 Assert.AreEqual("attachment", blob2.Properties.ContentDisposition);
-#if !ASPNET_K
                 Assert.AreEqual("gzip", blob2.Properties.ContentEncoding);
-#endif
                 Assert.AreEqual("tr,en", blob2.Properties.ContentLanguage);
                 Assert.AreEqual("MDAwMDAwMDA=", blob2.Properties.ContentMD5);
                 Assert.AreEqual("text/html", blob2.Properties.ContentType);

--- a/Test/WindowsRuntime/Blob/CloudPageBlobTest.cs
+++ b/Test/WindowsRuntime/Blob/CloudPageBlobTest.cs
@@ -397,10 +397,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
                 blob.Properties.CacheControl = "no-transform";
                 blob.Properties.ContentDisposition = "attachment";
-#if !ASPNET_K
-                //setting this will cause HttpClient DownloadToStreamAsync error due to ASPNET CLR HttpClient's behavior
                 blob.Properties.ContentEncoding = "gzip";
-#endif
                 blob.Properties.ContentLanguage = "tr,en";
                 blob.Properties.ContentMD5 = "MDAwMDAwMDA=";
                 blob.Properties.ContentType = "text/html";
@@ -412,10 +409,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 await blob2.FetchAttributesAsync();
                 Assert.AreEqual("no-transform", blob2.Properties.CacheControl);
                 Assert.AreEqual("attachment", blob2.Properties.ContentDisposition);
-#if !ASPNET_K
-                //HttpClient will not set this property after unzip the content automatically
                 Assert.AreEqual("gzip", blob2.Properties.ContentEncoding);
-#endif
                 Assert.AreEqual("tr,en", blob2.Properties.ContentLanguage);
                 Assert.AreEqual("MDAwMDAwMDA=", blob2.Properties.ContentMD5);
                 Assert.AreEqual("text/html", blob2.Properties.ContentType);

--- a/Test/WindowsRuntime/Blob/SASTests.cs
+++ b/Test/WindowsRuntime/Blob/SASTests.cs
@@ -354,9 +354,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 {
                     CacheControl = "no-transform",
                     ContentDisposition = "attachment",
-#if !ASPNET_K
                     ContentEncoding = "gzip",
-#endif
                     ContentLanguage = "tr,en",
                     ContentType = "text/html"
                 };
@@ -381,9 +379,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 {
                     CacheControl = "no-transform",
                     ContentDisposition = "attachment",
-#if !ASPNET_K
                     ContentEncoding = "gzip",
-#endif
                     ContentLanguage = "tr,en",
                     ContentType = "text/html"
                 };

--- a/Test/WindowsRuntime/File/CloudFileTest.cs
+++ b/Test/WindowsRuntime/File/CloudFileTest.cs
@@ -262,9 +262,7 @@ namespace Microsoft.WindowsAzure.Storage.File
                 await Task.Delay(1000);
 
                 file.Properties.CacheControl = "no-transform";
-#if !ASPNET_K
                 file.Properties.ContentEncoding = "gzip";
-#endif
                 file.Properties.ContentLanguage = "tr,en";
                 file.Properties.ContentMD5 = "MDAwMDAwMDA=";
                 file.Properties.ContentType = "text/html";
@@ -275,9 +273,7 @@ namespace Microsoft.WindowsAzure.Storage.File
                 CloudFile file2 = share.GetRootDirectoryReference().GetFileReference("file1");
                 await file2.FetchAttributesAsync();
                 Assert.AreEqual("no-transform", file2.Properties.CacheControl);
-#if !ASPNET_K
                 Assert.AreEqual("gzip", file2.Properties.ContentEncoding);
-#endif
                 Assert.AreEqual("tr,en", file2.Properties.ContentLanguage);
                 Assert.AreEqual("MDAwMDAwMDA=", file2.Properties.ContentMD5);
                 Assert.AreEqual("text/html", file2.Properties.ContentType);

--- a/Test/WindowsRuntime/Properties/AssemblyInfo.cs
+++ b/Test/WindowsRuntime/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.2.0")]
-[assembly: AssemblyFileVersion("7.0.2.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 [assembly: ComVisible(false)]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,22 @@
+Changes in 7.1.1-preview :
+
+- All : CoreCLR projects were updated to use the RTM release of .Net Core 1.0
+
 Changes in 7.1.0 :
 
+- All: Support for 2015-12-11 REST version. Please see our REST API documentation and blogs for information about the related added features. If you are using the Storage Emulator, please update to Emulator version 4.4.
+- Blobs: Added support for server-side encryption.
 - All: Fixed a bug with ContinuationToken where empty TargetLocation resulted in an error in deserialization.
 - Blobs/Tables/Queues: Bug fix and tests for running GetServiceStats with the incompatible PrimaryOnly location mode.
+- All (WinRT): Fixed a bug where HttpClient default timeout caused unhandled TaskCancellation exceptions.
+- All (CoreCLR): Updated the default AutomaticDecompression Method on StorageAuthenticationHttpHandler from Gzip | Deflate to None.
+- Table (CoreCLR) : Fixed a bug where reading table entity properties returned only the declared properties.
+ 
 
 Changes in 7.0.2-preview :
 
 - Blobs (WinRT): Fixed a bug that caused DownloadToFile() to infinite loop for one overload.
-- All: CoreCLR projects were updated to use the RC2 release of .Net Core 1.0
+- All : CoreCLR projects were updated to use the RC2 release of .Net Core 1.0
 
 Changes in 7.0.0 :
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "projects": [ "lib", "Lib/AspNet" ],
     "sdk": {
-        "version": "1.0.0-preview1-002702"
+        "version": "1.0.0-preview2-003121"
     }
 }


### PR DESCRIPTION
…M update, Desktop, RT and CoreCLR bug fixes

-- Added the private constructor to fully comply with singleton pattern in the handler class.
-- Updated Readme according to Microsoft Open Source Code of Conduct Policy
-- All (CoreCLR): Updated the default AutomaticDecompression Method on StorageAuthenticationHttpHandler from Gzip | Deflate to None
-- Table (CoreCLR) : Fixed a bug where reading table entity properties returned only the declared properties
-- All (WinRT): Fixed a bug where HttpClient default timeout caused unhandled TaskCancellation exceptions
-- All (WinRT) Fix uncaught TaskCancellation exception due to HttpClient default timeout
-- All: Support for 2015-12-11 REST version. Please see our REST API documentation and blogs for information about the related added features.
-- Blobs: Added support for server-side encryption.
-- All: Fixed a bug with ContinuationToken where empty TargetLocation resulted in an error in deserialization.
-- Blobs/Tables/Queues: Bug fix and tests for running GetServiceStats with the incompatible PrimaryOnly location mode.
-- Update dependecies to RTM bits of NetCore 1.0