### PR TITLE
[RT][CoreCLR] Changes to wrap error streams in a noncloseable stream

### DIFF
--- a/Lib/Common/StorageExtendedErrorInformation.cs
+++ b/Lib/Common/StorageExtendedErrorInformation.cs
@@ -15,9 +15,11 @@
 // </copyright>
 // -----------------------------------------------------------------------------------------
 
+
 namespace Microsoft.WindowsAzure.Storage
 {
     using Microsoft.Data.OData;
+    using Microsoft.WindowsAzure.Storage.Core;
     using Microsoft.WindowsAzure.Storage.Core.Util;
     using Microsoft.WindowsAzure.Storage.Shared.Protocol;
     using Microsoft.WindowsAzure.Storage.Table.Protocol;
@@ -129,7 +131,7 @@ namespace Microsoft.WindowsAzure.Storage
                 return null;
             }
 
-            HttpResponseAdapterMessage responseMessage = new HttpResponseAdapterMessage(response, inputStream, contentType);
+            HttpResponseAdapterMessage responseMessage = new HttpResponseAdapterMessage(response, new NonCloseableStream(inputStream), contentType);
             return ReadAndParseExtendedError(responseMessage);
         }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Changes in 7.1.4 :
 - All (CoreCLR): NetStandard target framework changed to netstandard1.3
 - All (PCL): Removed support for PCL in favor of NetStandard GA release
 - Table (CoreCLR) : Added a workaround for missing GetProperties method on TypeInfo in reflection-based Read/Write methods in TableEntity after change to netstandard11.3 TFM
+- Table (CoreCLR) : Added logic to wrap the error stream in a noncloseable stream to prevent it from being disposed by ODataMessageReader
 
 Changes in 7.1.3-preview :
 


### PR DESCRIPTION
-- A workaround to prevent the error stream from being disposed by non-configurable dispose-logic in ODataMessageReader (Fixes #320 )