### PR TITLE
 #426 TargetParameterCountException : Parameter count mismatch when using lists

### DIFF
--- a/Lib/Common/Table/EntityPropertyConverter.cs
+++ b/Lib/Common/Table/EntityPropertyConverter.cs
@@ -147,7 +147,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
             }
 
             // Better support for IEnumerable
-            if (current is IEnumerable)
+			if (current is IEnumerable && !(current is string))
                 current = string.Format("_$¿={0}", JsonConvert.SerializeObject(current, GetSerialisationSettings()));
 
             Type type = current.GetType();

--- a/Lib/Common/Table/EntityPropertyConverter.cs
+++ b/Lib/Common/Table/EntityPropertyConverter.cs
@@ -141,29 +141,29 @@ namespace Microsoft.WindowsAzure.Storage.Table
             EntityPropertyConverterOptions entityPropertyConverterOptions,
             OperationContext operationContext)
         {
-			if (current == null)
-			{
-				return true;
-			}
+            if (current == null)
+            {
+                return true;
+            }
 
-			bool firstRun = false;
-			Type type;
-			do
-			{
-				firstRun = !firstRun;
+            bool firstRun = false;
+            Type type;
+            do
+            {
+                firstRun = !firstRun;
 
-				type = current.GetType();
-				EntityProperty entityProperty = CreateEntityPropertyWithType(current, type);
+                type = current.GetType();
+                EntityProperty entityProperty = CreateEntityPropertyWithType(current, type);
 
-				if (entityProperty != null)
-				{
-					propertyDictionary.Add(objectPath, entityProperty);
-					return true;
-				}
-				// Better support for IEnumerable
-				if (current is IEnumerable && !(current is string))
-					current = string.Format("_$¿={0}", JsonConvert.SerializeObject(current, GetSerialisationSettings()));
-			} while (firstRun);
+                if (entityProperty != null)
+                {
+                    propertyDictionary.Add(objectPath, entityProperty);
+                    return true;
+                }
+                // Better support for IEnumerable
+                if (current is IEnumerable && !(current is string))
+                    current = string.Format("_$¿={0}", JsonConvert.SerializeObject(current, GetSerialisationSettings()));
+            } while (firstRun);
 
 #if WINDOWS_RT
             IEnumerable<PropertyInfo> propertyInfos = type.GetRuntimeProperties();

--- a/Lib/Common/Table/EntityPropertyConverter.cs
+++ b/Lib/Common/Table/EntityPropertyConverter.cs
@@ -146,12 +146,9 @@ namespace Microsoft.WindowsAzure.Storage.Table
                 return true;
             }
 
-            bool firstRun = false;
             Type type;
             do
             {
-                firstRun = !firstRun;
-
                 type = current.GetType();
                 EntityProperty entityProperty = CreateEntityPropertyWithType(current, type);
 
@@ -163,7 +160,9 @@ namespace Microsoft.WindowsAzure.Storage.Table
                 // Better support for IEnumerable
                 if (current is IEnumerable && !(current is string))
                     current = string.Format("_$¿={0}", JsonConvert.SerializeObject(current, GetSerialisationSettings()));
-            } while (firstRun);
+                else
+                    break;
+            } while (true);
 
 #if WINDOWS_RT
             IEnumerable<PropertyInfo> propertyInfos = type.GetRuntimeProperties();

--- a/Lib/Common/Table/EntityPropertyConverter.cs
+++ b/Lib/Common/Table/EntityPropertyConverter.cs
@@ -141,23 +141,29 @@ namespace Microsoft.WindowsAzure.Storage.Table
             EntityPropertyConverterOptions entityPropertyConverterOptions,
             OperationContext operationContext)
         {
-            if (current == null)
-            {
-                return true;
-            }
+			if (current == null)
+			{
+				return true;
+			}
 
-            // Better support for IEnumerable
-			if (current is IEnumerable && !(current is string))
-                current = string.Format("_$¿={0}", JsonConvert.SerializeObject(current, GetSerialisationSettings()));
+			bool firstRun = false;
+			Type type;
+			do
+			{
+				firstRun = !firstRun;
 
-            Type type = current.GetType();
-            EntityProperty entityProperty = CreateEntityPropertyWithType(current, type);
+				type = current.GetType();
+				EntityProperty entityProperty = CreateEntityPropertyWithType(current, type);
 
-            if (entityProperty != null)
-            {
-                propertyDictionary.Add(objectPath, entityProperty);
-                return true;
-            }
+				if (entityProperty != null)
+				{
+					propertyDictionary.Add(objectPath, entityProperty);
+					return true;
+				}
+				// Better support for IEnumerable
+				if (current is IEnumerable && !(current is string))
+					current = string.Format("_$¿={0}", JsonConvert.SerializeObject(current, GetSerialisationSettings()));
+			} while (firstRun);
 
 #if WINDOWS_RT
             IEnumerable<PropertyInfo> propertyInfos = type.GetRuntimeProperties();


### PR DESCRIPTION
Added automatic support for IEnumerables by serlialising the value to JSON - at least it won't throw an exception or drop the value.

Also any unsupported value that would have thrown an exception serialising will be serialised to JSON... the deserialisation of this could be interesting if there is no setter.