### PR TITLE
Task 1192950: Connection string improvements

### DIFF
--- a/Lib/Common/Auth/StorageCredentials.cs
+++ b/Lib/Common/Auth/StorageCredentials.cs
@@ -48,7 +48,7 @@ namespace Microsoft.WindowsAzure.Storage.Auth
         /// Gets the associated account name for the credentials.
         /// </summary>
         /// <value>The account name.</value>
-        public string AccountName { get; private set; }
+        public string AccountName { get; internal set; }
 
         /// <summary>
         /// Gets the associated key name for the credentials.
@@ -342,7 +342,13 @@ namespace Microsoft.WindowsAzure.Storage.Auth
 
             if (this.IsSAS)
             {
-                return string.Format(CultureInfo.InvariantCulture, "{0}={1}", CloudStorageAccount.SharedAccessSignatureSettingString, exportSecrets ? this.SASToken : "[signature hidden]");
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}={1};{2}={3}",
+                    CloudStorageAccount.AccountNameSettingString,
+                    this.AccountName,
+                    CloudStorageAccount.SharedAccessSignatureSettingString,
+                    exportSecrets ? this.SASToken : "[signature hidden]");
             }
 
             return string.Empty;

--- a/Lib/Common/Auth/StorageCredentials.cs
+++ b/Lib/Common/Auth/StorageCredentials.cs
@@ -48,7 +48,7 @@ namespace Microsoft.WindowsAzure.Storage.Auth
         /// Gets the associated account name for the credentials.
         /// </summary>
         /// <value>The account name.</value>
-        public string AccountName { get; internal set; }
+        public string AccountName { get; private set; }
 
         /// <summary>
         /// Gets the associated key name for the credentials.
@@ -342,13 +342,7 @@ namespace Microsoft.WindowsAzure.Storage.Auth
 
             if (this.IsSAS)
             {
-                return string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0}={1};{2}={3}",
-                    CloudStorageAccount.AccountNameSettingString,
-                    this.AccountName,
-                    CloudStorageAccount.SharedAccessSignatureSettingString,
-                    exportSecrets ? this.SASToken : "[signature hidden]");
+                return string.Format(CultureInfo.InvariantCulture, "{0}={1}", CloudStorageAccount.SharedAccessSignatureSettingString, exportSecrets ? this.SASToken : "[signature hidden]");
             }
 
             return string.Empty;

--- a/Lib/Common/CloudStorageAccount.cs
+++ b/Lib/Common/CloudStorageAccount.cs
@@ -1146,7 +1146,7 @@ namespace Microsoft.WindowsAzure.Storage
         }
 
         /// <summary>
-        /// Settings filter that ensures that all filters match.
+        /// Settings filter that ensures that all of the specified filters match.
         /// </summary>
         /// <param name="filters">A list of filters of which all must match.</param>
         /// <returns>The remaining settings or <c>null</c> if the filter's requirement is not satisfied.</returns>

--- a/Lib/Common/CloudStorageAccount.cs
+++ b/Lib/Common/CloudStorageAccount.cs
@@ -499,6 +499,11 @@ namespace Microsoft.WindowsAzure.Storage
         public StorageCredentials Credentials { get; private set; }
 
         /// <summary>
+        /// Private record of the account name for use in ToString(bool).
+        /// </summary>
+        private string AccountName { get; set; }
+
+        /// <summary>
         /// Parses a connection string and returns a <see cref="CloudStorageAccount"/> created
         /// from the connection string.
         /// </summary>
@@ -728,6 +733,11 @@ namespace Microsoft.WindowsAzure.Storage
                 listOfSettings.Add(this.Credentials.ToString(exportSecrets));
             }
 
+            if (!string.IsNullOrWhiteSpace(this.AccountName) && (this.Credentials != null ? string.IsNullOrWhiteSpace(this.Credentials.AccountName) : true))
+            {
+                listOfSettings.Add(string.Format(CultureInfo.InvariantCulture, "{0}={1}", AccountNameSettingString, this.AccountName));
+            }
+
             return string.Join(";", listOfSettings);
         }
 
@@ -937,6 +947,8 @@ namespace Microsoft.WindowsAzure.Storage
                             EndpointSuffix = settingOrDefault(EndpointSuffixSettingString),
                             Settings = ValidCredentials(settings)
                         };
+
+                    accountInformation.AccountName = settingOrDefault(AccountNameSettingString);
 
                     return true;
                 }
@@ -1329,7 +1341,7 @@ namespace Microsoft.WindowsAzure.Storage
 
             if (accountKey == null && accountKeyName == null && sharedAccessSignature != null)
             {
-                return new StorageCredentials(sharedAccessSignature) { AccountName = accountName };
+                return new StorageCredentials(sharedAccessSignature);
             }
 
             return null;

--- a/Lib/Common/CloudStorageAccount.cs
+++ b/Lib/Common/CloudStorageAccount.cs
@@ -502,7 +502,7 @@ namespace Microsoft.WindowsAzure.Storage
         /// <summary>
         /// Private record of the account name for use in ToString(bool).
         /// </summary>
-        private string AccountName { get; set; }
+        private string accountName;
 
         /// <summary>
         /// Parses a connection string and returns a <see cref="CloudStorageAccount"/> created
@@ -734,9 +734,9 @@ namespace Microsoft.WindowsAzure.Storage
                 listOfSettings.Add(this.Credentials.ToString(exportSecrets));
             }
 
-            if (!string.IsNullOrWhiteSpace(this.AccountName) && (this.Credentials != null ? string.IsNullOrWhiteSpace(this.Credentials.AccountName) : true))
+            if (!string.IsNullOrWhiteSpace(this.accountName) && (this.Credentials != null ? string.IsNullOrWhiteSpace(this.Credentials.AccountName) : true))
             {
-                listOfSettings.Add(string.Format(CultureInfo.InvariantCulture, "{0}={1}", AccountNameSettingString, this.AccountName));
+                listOfSettings.Add(string.Format(CultureInfo.InvariantCulture, "{0}={1}", AccountNameSettingString, this.accountName));
             }
 
             return string.Join(";", listOfSettings);
@@ -952,7 +952,7 @@ namespace Microsoft.WindowsAzure.Storage
                             Settings = ValidCredentials(settings)
                         };
 
-                    accountInformation.AccountName = settingOrDefault(AccountNameSettingString);
+                    accountInformation.accountName = settingOrDefault(AccountNameSettingString);
 
                     return true;
                 }

--- a/Test/Common/Core/CloudStorageAccountTests.cs
+++ b/Test/Common/Core/CloudStorageAccountTests.cs
@@ -747,7 +747,10 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
         private void connectionStringRoundtripHelper(string accountString)
         {
             CloudStorageAccount originalAccount = CloudStorageAccount.Parse(accountString);
-            CloudStorageAccount copiedAccount = CloudStorageAccount.Parse(originalAccount.ToString(true));
+
+            var copiedAccountString = originalAccount.ToString(true);
+
+            CloudStorageAccount copiedAccount = CloudStorageAccount.Parse(copiedAccountString);
 
             // make sure it round trips
             this.AccountsAreEqual(originalAccount, copiedAccount);

--- a/Test/Common/Core/CloudStorageAccountTests.cs
+++ b/Test/Common/Core/CloudStorageAccountTests.cs
@@ -579,43 +579,91 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
             connectionStringRoundtripHelper(accountString3);
             connectionStringRoundtripHelper(accountString4);
 
-            // shared access
-
-            string sas = "sasTest";
-
             string accountString5 =
                 string.Format(
-                    "DefaultEndpointsProtocol=http;AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};",
-                    accountSasParams);
+                    "AccountName={0};AccountKey={1};EndpointSuffix={2};",
+                    accountKeyParams);
 
             string accountString6 =
                 string.Format(
-                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};",
-                    accountSasParams);
+                    "AccountName={0};AccountKey={1};",
+                    accountKeyParams);
 
             string accountString7 =
                 string.Format(
-                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};QueueEndpoint={3}",
-                    accountSasParams);
+                    "AccountName={0};AccountKey={1};QueueEndpoint={3}",
+                    accountKeyParams);
 
             string accountString8 =
                 string.Format(
-                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};QueueEndpoint={3}",
-                    accountSasParams);
+                    "AccountName={0};AccountKey={1};EndpointSuffix={2};QueueEndpoint={3}",
+                    accountKeyParams);
 
             connectionStringRoundtripHelper(accountString5);
             connectionStringRoundtripHelper(accountString6);
             connectionStringRoundtripHelper(accountString7);
             connectionStringRoundtripHelper(accountString8);
 
-            // shared access no account name
+            // shared access
+
+            string accountString9 =
+                string.Format(
+                    "DefaultEndpointsProtocol=http;AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};",
+                    accountSasParams);
+
+            string accountString10 =
+                string.Format(
+                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};",
+                    accountSasParams);
 
             string accountString11 =
+                string.Format(
+                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};QueueEndpoint={3}",
+                    accountSasParams);
+
+            string accountString12 =
+                string.Format(
+                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};QueueEndpoint={3}",
+                    accountSasParams);
+
+            connectionStringRoundtripHelper(accountString9);
+            connectionStringRoundtripHelper(accountString10);
+            connectionStringRoundtripHelper(accountString11);
+            connectionStringRoundtripHelper(accountString12);
+
+            string accountString13 =
+                string.Format(
+                    "AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};",
+                    accountSasParams);
+
+            string accountString14 =
+                string.Format(
+                    "AccountName={0};SharedAccessSignature={1};",
+                    accountSasParams);
+
+            string accountString15 =
+                string.Format(
+                    "AccountName={0};SharedAccessSignature={1};QueueEndpoint={3}",
+                    accountSasParams);
+
+            string accountString16 =
+                string.Format(
+                    "AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};QueueEndpoint={3}",
+                    accountSasParams);
+
+            connectionStringRoundtripHelper(accountString13);
+            connectionStringRoundtripHelper(accountString14);
+            connectionStringRoundtripHelper(accountString15);
+            connectionStringRoundtripHelper(accountString16);
+
+            // shared access no account name
+
+            string accountString17 =
                 string.Format(
                     "SharedAccessSignature={1};QueueEndpoint={3}",
                     accountSasParams);
 
-            connectionStringRoundtripHelper(accountString11);
+            connectionStringRoundtripHelper(accountString17);
         }
 
         [TestMethod]
@@ -682,6 +730,34 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
 
                 CloudStorageAccount.Parse(accountStringKeyPrimarySecondary); // no exception expected
 
+                // account key, no default protocol
+
+                string accountStringKeyNoDefaultProtocolPrimary =
+                    string.Format(
+                        "AccountName={0};AccountKey={1};EndpointSuffix={2};" + endpointCombination[0],
+                        accountKeyParams
+                        );
+
+                string accountStringKeyNoDefaultProtocolSecondary =
+                    string.Format(
+                        "AccountName={0};AccountKey={1};EndpointSuffix={2};" + endpointCombination[1],
+                        accountKeyParams
+                        );
+
+
+                string accountStringKeyNoDefaultProtocolPrimarySecondary =
+                    string.Format(
+                        "AccountName={0};AccountKey={1};EndpointSuffix={2};" + endpointCombination[2],
+                        accountKeyParams
+                        );
+
+
+                CloudStorageAccount.Parse(accountStringKeyNoDefaultProtocolPrimary); // no exception expected
+
+                TestHelper.ExpectedException<FormatException>(() => CloudStorageAccount.Parse(accountStringKeyNoDefaultProtocolSecondary), "connection string parse", "No valid combination of account information found.");
+
+                CloudStorageAccount.Parse(accountStringKeyNoDefaultProtocolPrimarySecondary); // no exception expected
+
                 // SAS
 
                 string accountStringSasPrimary =
@@ -707,6 +783,32 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
                 TestHelper.ExpectedException<FormatException>(() => CloudStorageAccount.Parse(accountStringSasSecondary), "connection string parse", "No valid combination of account information found.");
 
                 CloudStorageAccount.Parse(accountStringSasPrimarySecondary); // no exception expected
+
+                // SAS, no default protocol
+
+                string accountStringSasNoDefaultProtocolPrimary =
+                    string.Format(
+                        "AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};" + endpointCombination[0],
+                        accountSasParams
+                        );
+
+                string accountStringSasNoDefaultProtocolSecondary =
+                    string.Format(
+                        "AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};" + endpointCombination[1],
+                        accountSasParams
+                        );
+
+                string accountStringSasNoDefaultProtocolPrimarySecondary =
+                    string.Format(
+                        "AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};" + endpointCombination[2],
+                        accountSasParams
+                        );
+
+                CloudStorageAccount.Parse(accountStringSasNoDefaultProtocolPrimary); // no exception expected
+
+                TestHelper.ExpectedException<FormatException>(() => CloudStorageAccount.Parse(accountStringSasNoDefaultProtocolSecondary), "connection string parse", "No valid combination of account information found.");
+
+                CloudStorageAccount.Parse(accountStringSasNoDefaultProtocolPrimarySecondary); // no exception expected
 
                 // SAS without AccountName
 
@@ -945,19 +1047,6 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
         }
 
         [TestMethod]
-        [Description("ToString method for custom endpoints should return the same connection string")]
-        [TestCategory(ComponentCategory.Core)]
-        [TestCategory(TestTypeCategory.UnitTest)]
-        [TestCategory(SmokeTestCategory.NonSmoke)]
-        [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
-        public void CloudStorageAccountExplicitCloudRoundtrip()
-        {
-            string accountString = "BlobEndpoint=https://blobs/;AccountName=test;AccountKey=abc=";
-
-            Assert.AreEqual(accountString, CloudStorageAccount.Parse(accountString).ToString(true));
-        }
-
-        [TestMethod]
         [Description("ToString method for anonymous credentials should return the same connection string")]
         [TestCategory(ComponentCategory.Core)]
         [TestCategory(TestTypeCategory.UnitTest)]
@@ -972,72 +1061,6 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
             CloudStorageAccount account = new CloudStorageAccount(null, new Uri("http://blobs/"), null, null, null);
 
             AccountsAreEqual(account, CloudStorageAccount.Parse(account.ToString(true)));
-        }
-
-        [TestMethod]
-        [Description("Parse method should ignore empty values")]
-        [TestCategory(ComponentCategory.Core)]
-        [TestCategory(TestTypeCategory.UnitTest)]
-        [TestCategory(SmokeTestCategory.NonSmoke)]
-        [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
-        public void CloudStorageAccountEmptyValues()
-        {
-            string accountString = ";BlobEndpoint=http://blobs/;;AccountName=test;;AccountKey=abc=;";
-            string validAccountString = "BlobEndpoint=http://blobs/;AccountName=test;AccountKey=abc=";
-
-            Assert.AreEqual(validAccountString, CloudStorageAccount.Parse(accountString).ToString(true));
-        }
-
-        [TestMethod]
-        [Description("ToString method with custom blob endpoint should return the same connection string")]
-        [TestCategory(ComponentCategory.Core)]
-        [TestCategory(TestTypeCategory.UnitTest)]
-        [TestCategory(SmokeTestCategory.NonSmoke)]
-        [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
-        public void CloudStorageAccountJustBlobToString()
-        {
-            string accountString = "BlobEndpoint=http://blobs/;AccountName=test;AccountKey=abc=";
-
-            Assert.AreEqual(accountString, CloudStorageAccount.Parse(accountString).ToString(true));
-        }
-
-        [TestMethod]
-        [Description("ToString method with custom queue endpoint should return the same connection string")]
-        [TestCategory(ComponentCategory.Core)]
-        [TestCategory(TestTypeCategory.UnitTest)]
-        [TestCategory(SmokeTestCategory.NonSmoke)]
-        [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
-        public void CloudStorageAccountJustQueueToString()
-        {
-            string accountString = "QueueEndpoint=http://queue/;AccountName=test;AccountKey=abc=";
-
-            Assert.AreEqual(accountString, CloudStorageAccount.Parse(accountString).ToString(true));
-        }
-
-        [TestMethod]
-        [Description("ToString method with custom table endpoint should return the same connection string")]
-        [TestCategory(ComponentCategory.Core)]
-        [TestCategory(TestTypeCategory.UnitTest)]
-        [TestCategory(SmokeTestCategory.NonSmoke)]
-        [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
-        public void CloudStorageAccountJustTableToString()
-        {
-            string accountString = "TableEndpoint=http://table/;AccountName=test;AccountKey=abc=";
-
-            Assert.AreEqual(accountString, CloudStorageAccount.Parse(accountString).ToString(true));
-        }
-
-        [TestMethod]
-        [Description("ToString method with custom file endpoint should return the same connection string")]
-        [TestCategory(ComponentCategory.Core)]
-        [TestCategory(TestTypeCategory.UnitTest)]
-        [TestCategory(SmokeTestCategory.NonSmoke)]
-        [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
-        public void CloudStorageAccountJustFileToString()
-        {
-            string accountString = "FileEndpoint=http://file/;AccountName=test;AccountKey=abc=";
-
-            Assert.AreEqual(accountString, CloudStorageAccount.Parse(accountString).ToString(true));
         }
 
         [TestMethod]

--- a/Test/Common/Core/CloudStorageAccountTests.cs
+++ b/Test/Common/Core/CloudStorageAccountTests.cs
@@ -534,35 +534,45 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
         [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
         public void CloudStorageAccountConnectionStringRoundtrip()
         {
+            string[] accountKeyParams = new[] 
+                {
+                    TestBase.TargetTenantConfig.AccountName,
+                    TestBase.TargetTenantConfig.AccountKey,
+                    "fake.endpoint.suffix",
+                    "https://primary.endpoint/",
+                    "https://secondary.endpoint/"
+                };
+
+            string[] accountSasParams = new[] 
+                {
+                    TestBase.TargetTenantConfig.AccountName,
+                    "sasTest",
+                    "fake.endpoint.suffix",
+                    "https://primary.endpoint/",
+                    "https://secondary.endpoint/"
+                };
+
             // account key
 
             string accountString1 =
                 string.Format(
                     "DefaultEndpointsProtocol=http;AccountName={0};AccountKey={1};EndpointSuffix={2};",
-                    TestBase.TargetTenantConfig.AccountName,
-                    TestBase.TargetTenantConfig.AccountKey,
-                    "fake.endpoint.suffix");
+                    accountKeyParams);
 
             string accountString2 =
                 string.Format(
                     "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};",
-                    TestBase.TargetTenantConfig.AccountName,
-                    TestBase.TargetTenantConfig.AccountKey);
+                    accountKeyParams);
 
             string accountString3 =
                 string.Format(
-                    "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};QueueEndpoint={2}",
-                    TestBase.TargetTenantConfig.AccountName,
-                    TestBase.TargetTenantConfig.AccountKey,
-                    "https://alternate.queue.endpoint/");
+                    "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};QueueEndpoint={3}",
+                    accountKeyParams);
 
             string accountString4 =
                 string.Format(
                     "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2};QueueEndpoint={3}",
-                    TestBase.TargetTenantConfig.AccountName,
-                    TestBase.TargetTenantConfig.AccountKey,
-                    "fake.endpoint.suffix",
-                    "https://alternate.queue.endpoint/");
+                    accountKeyParams);
 
             connectionStringRoundtripHelper(accountString1);
             connectionStringRoundtripHelper(accountString2);
@@ -571,35 +581,27 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
 
             // shared access
 
-            var sas = "sasTest";
+            string sas = "sasTest";
 
             string accountString5 =
                 string.Format(
                     "DefaultEndpointsProtocol=http;AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};",
-                    TestBase.TargetTenantConfig.AccountName,
-                    sas,
-                    "fake.endpoint.suffix");
+                    accountSasParams);
 
             string accountString6 =
                 string.Format(
                     "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};",
-                    TestBase.TargetTenantConfig.AccountName,
-                    sas);
+                    accountSasParams);
 
             string accountString7 =
                 string.Format(
-                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};QueueEndpoint={2}",
-                    TestBase.TargetTenantConfig.AccountName,
-                    sas,
-                    "https://alternate.queue.endpoint/");
+                    "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};QueueEndpoint={3}",
+                    accountSasParams);
 
             string accountString8 =
                 string.Format(
                     "DefaultEndpointsProtocol=https;AccountName={0};SharedAccessSignature={1};EndpointSuffix={2};QueueEndpoint={3}",
-                    TestBase.TargetTenantConfig.AccountName,
-                    sas,
-                    "fake.endpoint.suffix",
-                    "https://alternate.queue.endpoint/");
+                    accountSasParams);
 
             connectionStringRoundtripHelper(accountString5);
             connectionStringRoundtripHelper(accountString6);
@@ -610,10 +612,8 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
 
             string accountString11 =
                 string.Format(
-                    "SharedAccessSignature={1};QueueEndpoint={2}",
-                    TestBase.TargetTenantConfig.AccountName,
-                    sas,
-                    "https://alternate.queue.endpoint/");
+                    "SharedAccessSignature={1};QueueEndpoint={3}",
+                    accountSasParams);
 
             connectionStringRoundtripHelper(accountString11);
         }
@@ -626,7 +626,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
         [TestCategory(TenantTypeCategory.DevStore), TestCategory(TenantTypeCategory.DevFabric), TestCategory(TenantTypeCategory.Cloud)]
         public void CloudStorageAccountConnectionStringExpectedExceptions()
         {
-            var endpointCombinations = new[]
+            string[][] endpointCombinations = new[]
                 {
                     new[] { "BlobEndpoint={3}", "BlobSecondaryEndpoint={4}", "BlobEndpoint={3};BlobSecondaryEndpoint={4}" },
                     new[] { "QueueEndpoint={3}", "QueueSecondaryEndpoint={4}", "QueueEndpoint={3};QueueSecondaryEndpoint={4}" },
@@ -634,7 +634,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
                     new[] { "FileEndpoint={3}", "FileSecondaryEndpoint={4}", "FileEndpoint={3};FileSecondaryEndpoint={4}" }
                 };
 
-            var accountKeyParams = new[] 
+            string[] accountKeyParams = new[] 
                 {
                     TestBase.TargetTenantConfig.AccountName,
                     TestBase.TargetTenantConfig.AccountKey,
@@ -643,7 +643,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
                     "https://secondary.endpoint/"
                 };
 
-            var accountSasParams = new[] 
+            string[] accountSasParams = new[] 
                 {
                     TestBase.TargetTenantConfig.AccountName,
                     "sasTest",
@@ -652,7 +652,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
                     "https://secondary.endpoint/"
                 };
 
-            foreach (var endpointCombination in endpointCombinations)
+            foreach (string[] endpointCombination in endpointCombinations)
             {
                 // account key
 
@@ -748,7 +748,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
         {
             CloudStorageAccount originalAccount = CloudStorageAccount.Parse(accountString);
 
-            var copiedAccountString = originalAccount.ToString(true);
+            string copiedAccountString = originalAccount.ToString(true);
 
             CloudStorageAccount copiedAccount = CloudStorageAccount.Parse(copiedAccountString);
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Changes in X.X.X :
+- All: Connection string support expanded to allow AccountName to be specified with SharedAccessSignature and DefaultEndpointsProtocol.  In this case, SharedAccessSignature is used for credentials, while having both DefaultEndpointsProtocol and AccountName allows the library to infer a set of default endpoints.  Additionally, we have added support for BlobSecondaryEndpoint, QueueSecondaryEndpoint, TableSecondaryEndpoint, and FileSecondaryEndpoint.  Specifying a secondary endpoint requires the specification of the corresponding primary.
+
 Changes in 8.0.1 :
 - (NetStandard/Xamarin) : Fix for a break in Xamarin Apps with Streaming APIs caused by NotImplemented IncrementalHash APIs in Xamarin Runtime.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Changes in X.X.X :
 - All: Connection string support expanded to allow AccountName to be specified with SharedAccessSignature and DefaultEndpointsProtocol.  In this case, SharedAccessSignature is used for credentials, while having both DefaultEndpointsProtocol and AccountName allows the library to infer a set of default endpoints.  Additionally, we have added support for BlobSecondaryEndpoint, QueueSecondaryEndpoint, TableSecondaryEndpoint, and FileSecondaryEndpoint.  Specifying a secondary endpoint requires the specification of the corresponding primary.
+- All: The use of DefaultEndpointsProtocol in a connection string is now optional in the case where endpoints would be automatically generated; if missing, a value of https will be inferred.  When the parsed account settings in such a case are used to generate a connection string, the value of DefaultEndpointsProtocol will be explicitly included.
 
 Changes in 8.0.1 :
 - (NetStandard/Xamarin) : Fix for a break in Xamarin Apps with Streaming APIs caused by NotImplemented IncrementalHash APIs in Xamarin Runtime.


### PR DESCRIPTION
Task 1192950: Adds SAS + Name to the cases of connection string parsing where endpoints are inferred; adds specification of secondary endpoints where primary is also specified; makes DefaultEndpointsProtocol optional; cleans up code and adds unit tests
