### PR TITLE
Fix misuse of System.Random in ExponentialRetry.cs

### DIFF
--- a/Lib/Common/RetryPolicies/ExponentialRetry.cs
+++ b/Lib/Common/RetryPolicies/ExponentialRetry.cs
@@ -102,7 +102,7 @@ namespace Microsoft.WindowsAzure.Storage.RetryPolicies
         {
             lock (randomLock)
             {
-                return Math.Pow(2, currentRetryCount) - 1) * random.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2);
+                return (Math.Pow(2, currentRetryCount) - 1) * r.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2));
             }
         }
 

--- a/Lib/Common/RetryPolicies/ExponentialRetry.cs
+++ b/Lib/Common/RetryPolicies/ExponentialRetry.cs
@@ -102,7 +102,7 @@ namespace Microsoft.WindowsAzure.Storage.RetryPolicies
         {
             lock (randomLock)
             {
-                return (Math.Pow(2, currentRetryCount) - 1) * r.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2));
+                return (Math.Pow(2, currentRetryCount) - 1) * random.Next((int)(this.deltaBackoff.TotalMilliseconds * 0.8), (int)(this.deltaBackoff.TotalMilliseconds * 1.2));
             }
         }
 

--- a/Lib/Common/RetryPolicies/ExponentialRetry.cs
+++ b/Lib/Common/RetryPolicies/ExponentialRetry.cs
@@ -31,7 +31,7 @@ namespace Microsoft.WindowsAzure.Storage.RetryPolicies
         private const int DefaultClientRetryCount = 3;
         private static readonly TimeSpan DefaultClientBackoff = TimeSpan.FromSeconds(4);
         private static readonly TimeSpan MaxBackoff = TimeSpan.FromSeconds(120);
-        private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(3);        
+        private static readonly TimeSpan MinBackoff = TimeSpan.FromSeconds(3);
 
         private TimeSpan deltaBackoff;
         private int maximumAttempts;


### PR DESCRIPTION
Changed the random instance to be created at the class level. This prevents multiple calls to the ShouldRetry instance in the same Environment.TickCount period (~15 milliseconds) receiving the exact same GetNext() values from the random instance. This random needs to be protected with a lock, as System.Random is not threadsafe (this is a very simple threadsafe implementation, for high concurrency there are more performant implementations of threadsafe random access at the cost of higher complexity)

e.g. see https://blogs.msdn.microsoft.com/pfxteam/2009/02/19/getting-random-numbers-in-a-thread-safe-way/