### PR TITLE
Avoid Task.Run and Factory.StartNew with async

### DIFF
--- a/Lib/AspNet/Microsoft.WindowsAzure.Storage/Extensions/StreamExtension.cs
+++ b/Lib/AspNet/Microsoft.WindowsAzure.Storage/Extensions/StreamExtension.cs
@@ -71,9 +71,9 @@ namespace Microsoft.WindowsAzure.Storage
         /// <param name="stream">input stream</param>
         /// <param name="buffer">buffer to write to the stream</param>
         /// <returns>Async task</returns>
-        public static async Task WriteAsync(this Stream stream, byte[] buffer)
+        public static Task WriteAsync(this Stream stream, byte[] buffer)
         {
-            await stream.WriteAsync(buffer, 0, buffer.Length);
+            return stream.WriteAsync(buffer, 0, buffer.Length);
         }
 
         /// <summary>

--- a/Lib/ClassLibraryCommon/Table/Protocol/HttpResponseAdapterMessage.cs
+++ b/Lib/ClassLibraryCommon/Table/Protocol/HttpResponseAdapterMessage.cs
@@ -27,7 +27,7 @@ namespace Microsoft.WindowsAzure.Storage.Table.Protocol
     internal class HttpResponseAdapterMessage : IODataResponseMessage
     {
         private HttpWebResponse resp = null;
-        private Stream str = null;
+        private Task<Stream> strAsCachedTask = null;
         private string responseContentType = null;
 
         public HttpResponseAdapterMessage(HttpWebResponse resp, Stream str)
@@ -38,13 +38,13 @@ namespace Microsoft.WindowsAzure.Storage.Table.Protocol
         public HttpResponseAdapterMessage(HttpWebResponse resp, Stream str, string responseContentType)
         {
             this.resp = resp;
-            this.str = str;
+            this.strAsCachedTask = Task.FromResult(str);
             this.responseContentType = responseContentType;
         }
 
         public Task<Stream> GetStreamAsync()
         {
-            return Task.Factory.StartNew(() => this.str);
+            return this.strAsCachedTask;
         }
 
         public string GetHeader(string headerName)
@@ -73,7 +73,7 @@ namespace Microsoft.WindowsAzure.Storage.Table.Protocol
 
         public Stream GetStream()
         {
-            return this.str;
+            return this.strAsCachedTask.Result; // safe since completed task and avoids additional field for stream
         }
 
         public IEnumerable<KeyValuePair<string, string>> Headers

--- a/Lib/Common/Core/MultiBufferMemoryStream.cs
+++ b/Lib/Common/Core/MultiBufferMemoryStream.cs
@@ -572,7 +572,7 @@ namespace Microsoft.WindowsAzure.Storage.Core
 
                     // Copy the block
                     int blockReadLength = (int)Math.Min(leftToRead, currentBlock.Count);
-                    await destination.WriteAsync(currentBlock.Array, currentBlock.Offset, blockReadLength);
+                    await destination.WriteAsync(currentBlock.Array, currentBlock.Offset, blockReadLength).ConfigureAwait(false);
 
                     this.AdvancePosition(ref leftToRead, blockReadLength);
                 }

--- a/Lib/Common/Core/NullType.cs
+++ b/Lib/Common/Core/NullType.cs
@@ -15,6 +15,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading.Tasks;
+
 namespace Microsoft.WindowsAzure.Storage.Core
 {
     /// <summary>
@@ -26,6 +28,11 @@ namespace Microsoft.WindowsAzure.Storage.Core
         /// Represents a no-return from a task.
         /// </summary>
         internal static readonly NullType Value = new NullType();
+
+        /// <summary>
+        /// Represents a no-return from a task.
+        /// </summary>
+        internal static readonly Task<NullType> ValueTask = Task.FromResult(Value);
 
         /// <summary>
         /// Prevents a default instance of the <see cref="NullType"/> class from being created.

--- a/Lib/Common/Core/Util/Exceptions.cs
+++ b/Lib/Common/Core/Util/Exceptions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Util
                     }
                     else
                     {
-                        currentResult.ExtendedErrorInformation = await StorageExtendedErrorInformation.ReadFromStreamAsync(errStream.AsInputStream());
+                        currentResult.ExtendedErrorInformation = await StorageExtendedErrorInformation.ReadFromStreamAsync(errStream.AsInputStream()).ConfigureAwait(false);
                     }
                 }
                 catch (Exception)

--- a/Lib/Common/StorageExtendedErrorInformation.cs
+++ b/Lib/Common/StorageExtendedErrorInformation.cs
@@ -77,9 +77,9 @@ namespace Microsoft.WindowsAzure.Storage
             return ReadFromStream(inputStream.AsStreamForRead());
         }
 
-        public static async Task<StorageExtendedErrorInformation> ReadFromStreamAsync(IInputStream inputStream)
+        public static Task<StorageExtendedErrorInformation> ReadFromStreamAsync(IInputStream inputStream)
         {
-            return await ReadFromStreamAsync(inputStream.AsStreamForRead());
+            return ReadFromStreamAsync(inputStream.AsStreamForRead());
         }
 #endif
 
@@ -139,7 +139,7 @@ namespace Microsoft.WindowsAzure.Storage
 
                 using (XmlReader reader = XmlReader.Create(inputStream, settings))
                 {
-                    await reader.ReadAsync();
+                    await reader.ReadAsync().ConfigureAwait(false);
                     extendedErrorInfo.ReadXml(reader);
                 }
 

--- a/Lib/WindowsDesktop/Table/DataServices/DataServicesResponseAdapterMessage.cs
+++ b/Lib/WindowsDesktop/Table/DataServices/DataServicesResponseAdapterMessage.cs
@@ -26,7 +26,7 @@ namespace Microsoft.WindowsAzure.Storage.Table.DataServices
     internal class DataServicesResponseAdapterMessage : IODataResponseMessage
     {
         private IDictionary<string, string> responseHeaders;
-        private Stream inputStream = null;
+        private Task<Stream> inputStreamAsCachedTask = null;
         private string responseContentType = null;
 
         public DataServicesResponseAdapterMessage(Dictionary<string, string> responseHeaders, Stream inputStream)
@@ -37,13 +37,13 @@ namespace Microsoft.WindowsAzure.Storage.Table.DataServices
         public DataServicesResponseAdapterMessage(IDictionary<string, string> responseHeaders, Stream inputStream, string responseContentType)
         {
             this.responseHeaders = responseHeaders;
-            this.inputStream = inputStream;
+            this.inputStreamAsCachedTask = Task.FromResult(inputStream);
             this.responseContentType = responseContentType;
         }
 
         public Task<Stream> GetStreamAsync()
         {
-            return Task.Factory.StartNew(() => this.inputStream);
+            return inputStreamAsCachedTask;
         }
 
         public string GetHeader(string headerName)
@@ -77,7 +77,7 @@ namespace Microsoft.WindowsAzure.Storage.Table.DataServices
 
         public Stream GetStream()
         {
-            return this.inputStream;
+            return this.inputStreamAsCachedTask.Result; // safe since completed task and avoids additional field for stream
         }
 
         public IEnumerable<KeyValuePair<string, string>> Headers

--- a/Lib/WindowsRuntime/Blob/BlobReadStream.cs
+++ b/Lib/WindowsRuntime/Blob/BlobReadStream.cs
@@ -95,7 +95,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="count">The maximum number of bytes to read.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CommonUtility.AssertNotNull("buffer", buffer);
             CommonUtility.AssertInBounds("offset", offset, 0, buffer.Length);
@@ -108,16 +108,16 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
             if ((this.currentOffset == this.Length) || (count == 0))
             {
-                return 0;
+                return Task.FromResult(0);
             }
 
             int readCount = this.ConsumeBuffer(buffer, offset, count);
             if (readCount > 0)
             {
-                return readCount;
+                return Task.FromResult(readCount);
             }
 
-            return await this.DispatchReadAsync(buffer, offset, count);
+            return this.DispatchReadAsync(buffer, offset, count);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                     this.GetReadSize(),
                     this.accessCondition,
                     this.options,
-                    this.operationContext);
+                    this.operationContext).ConfigureAwait(false);
 
                 this.internalBuffer.Seek(0, SeekOrigin.Begin);
                 return this.ConsumeBuffer(buffer, offset, count);

--- a/Lib/WindowsRuntime/Blob/BlobWriteStream.cs
+++ b/Lib/WindowsRuntime/Blob/BlobWriteStream.cs
@@ -158,7 +158,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
                 if (bytesToWrite == maxBytesToWrite)
                 {
-                    await this.DispatchWriteAsync();
+                    await this.DispatchWriteAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -188,7 +188,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 throw new InvalidOperationException(SR.BlobStreamAlreadyCommitted);
             }
 
-            await this.DispatchWriteAsync();
+            await this.DispatchWriteAsync().ConfigureAwait(false);
             await Task.Run(() => this.noPendingWritesEvent.Wait(), cancellationToken);
 
             if (this.lastException != null)
@@ -225,7 +225,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <returns>A task that represents the asynchronous commit operation.</returns>
         public override async Task CommitAsync()
         {
-            await this.FlushAsync();
+            await this.FlushAsync().ConfigureAwait(false);
             this.committed = true;
 
             try
@@ -237,14 +237,14 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                         this.blockBlob.Properties.ContentMD5 = this.blobMD5.ComputeHash();
                     }
 
-                    await this.blockBlob.PutBlockListAsync(this.blockList, this.accessCondition, this.options, this.operationContext);
+                    await this.blockBlob.PutBlockListAsync(this.blockList, this.accessCondition, this.options, this.operationContext).ConfigureAwait(false);
                 }
                 else
                 {
                     if (this.blobMD5 != null)
                     {
                         this.Blob.Properties.ContentMD5 = this.blobMD5.ComputeHash();
-                        await this.Blob.SetPropertiesAsync(this.accessCondition, this.options, this.operationContext);
+                        await this.Blob.SetPropertiesAsync(this.accessCondition, this.options, this.operationContext).ConfigureAwait(false);
                     }
                 }
             }
@@ -282,7 +282,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             {
                 string blockId = this.GetCurrentBlockId();
                 this.blockList.Add(blockId);
-                await this.WriteBlockAsync(bufferToUpload, blockId, bufferMD5);
+                await this.WriteBlockAsync(bufferToUpload, blockId, bufferMD5).ConfigureAwait(false);
             }
             else if (this.pageBlob != null)
             {
@@ -294,7 +294,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
                 long offset = this.currentBlobOffset;
                 this.currentBlobOffset += bufferToUpload.Length;
-                await this.WritePagesAsync(bufferToUpload, offset, bufferMD5);
+                await this.WritePagesAsync(bufferToUpload, offset, bufferMD5).ConfigureAwait(false);
             }
             else
             {
@@ -310,7 +310,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                     throw this.lastException;
                 }
 
-                await this.WriteAppendBlockAsync(bufferToUpload, offset, bufferMD5);
+                await this.WriteAppendBlockAsync(bufferToUpload, offset, bufferMD5).ConfigureAwait(false);
             }
         }
 
@@ -324,7 +324,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         private async Task WriteBlockAsync(Stream blockData, string blockId, string blockMD5)
         {
             this.noPendingWritesEvent.Increment();
-            await this.parallelOperationSemaphore.WaitAsync();
+            await this.parallelOperationSemaphore.WaitAsync().ConfigureAwait(false);
             Task putBlockTask = this.blockBlob.PutBlockAsync(blockId, blockData, blockMD5, this.accessCondition, this.options, this.operationContext).ContinueWith(task =>
             {
                 if (task.Exception != null)
@@ -347,7 +347,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         private async Task WritePagesAsync(Stream pageData, long offset, string contentMD5)
         {
             this.noPendingWritesEvent.Increment();
-            await this.parallelOperationSemaphore.WaitAsync();
+            await this.parallelOperationSemaphore.WaitAsync().ConfigureAwait(false);
             Task writePagesTask = this.pageBlob.WritePagesAsync(pageData, offset, contentMD5, this.accessCondition, this.options, this.operationContext).ContinueWith(task =>
             {
                 if (task.Exception != null)
@@ -372,7 +372,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         private async Task WriteAppendBlockAsync(Stream blockData, long offset, string blockMD5)
         {
             this.noPendingWritesEvent.Increment();
-            await this.parallelOperationSemaphore.WaitAsync();
+            await this.parallelOperationSemaphore.WaitAsync().ConfigureAwait(false);
 
             this.accessCondition.IfAppendPositionEqual = offset;
 

--- a/Lib/WindowsRuntime/Blob/CloudAppendBlob.cs
+++ b/Lib/WindowsRuntime/Blob/CloudAppendBlob.cs
@@ -958,7 +958,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
                     StreamDescriptor streamCopyState = new StreamDescriptor();
                     long startPosition = seekableStream.Position;
-                    await blockDataAsStream.WriteToAsync(writeToStream, null /* copyLength */, Constants.MaxAppendBlockSize, requiresContentMD5, tempExecutionState, streamCopyState, cancellationToken);
+                    await blockDataAsStream.WriteToAsync(writeToStream, null /* copyLength */, Constants.MaxAppendBlockSize, requiresContentMD5, tempExecutionState, streamCopyState, cancellationToken).ConfigureAwait(false);
                     seekableStream.Position = startPosition;
 
                     if (requiresContentMD5)

--- a/Lib/WindowsRuntime/Blob/CloudBlobClient.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlobClient.cs
@@ -559,7 +559,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             retCmd.BuildRequest = (cmd, uri, builder, cnt, serverTimeout, ctx) => BlobHttpRequestMessageFactory.GetServiceStats(uri, serverTimeout, ctx, this.GetCanonicalizer(), this.Credentials);
             retCmd.RetrieveResponseStream = true;
             retCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
-            retCmd.PostProcessResponse = (cmd, resp, ctx) => Task.Factory.StartNew(() => BlobHttpResponseParsers.ReadServiceStats(cmd.ResponseStream));
+            retCmd.PostProcessResponse = (cmd, resp, ctx) => Task.FromResult(BlobHttpResponseParsers.ReadServiceStats(cmd.ResponseStream));
             return retCmd;
         }
 #endregion

--- a/Lib/WindowsRuntime/Blob/CloudBlobClient.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlobClient.cs
@@ -111,19 +111,16 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A result segment of containers.</returns>
         [DoesServiceRequest]
-        public virtual Task<ContainerResultSegment> ListContainersSegmentedAsync(string prefix, ContainerListingDetails detailsIncluded, int? maxResults, BlobContinuationToken currentToken, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<ContainerResultSegment> ListContainersSegmentedAsync(string prefix, ContainerListingDetails detailsIncluded, int? maxResults, BlobContinuationToken currentToken, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
-            return Task.Run(async () =>
-            {
-                BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this);
-                ResultSegment<CloudBlobContainer> resultSegment = await Executor.ExecuteAsync(
-                    this.ListContainersImpl(prefix, detailsIncluded, currentToken, maxResults, modifiedOptions),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken);
+            BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this);
+            ResultSegment<CloudBlobContainer> resultSegment = await Executor.ExecuteAsync(
+                this.ListContainersImpl(prefix, detailsIncluded, currentToken, maxResults, modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken).ConfigureAwait(false);
 
-                return new ContainerResultSegment(resultSegment.Results, (BlobContinuationToken)resultSegment.ContinuationToken);
-            }, cancellationToken);
+            return new ContainerResultSegment(resultSegment.Results, (BlobContinuationToken)resultSegment.ContinuationToken);
         }
 
         /// <summary>
@@ -218,11 +215,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             CommonUtility.AssertNotNull("blobUri", blobUri);
 
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.GetBlobReferenceImpl(blobUri, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -251,24 +248,21 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             getCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task.Factory.StartNew(() =>
+                ListContainersResponse listContainersResponse = new ListContainersResponse(cmd.ResponseStream);
+                List<CloudBlobContainer> containersList = listContainersResponse.Containers.Select(item => new CloudBlobContainer(item.Properties, item.Metadata, item.Name, this)).ToList();
+                BlobContinuationToken continuationToken = null;
+                if (listContainersResponse.NextMarker != null)
                 {
-                    ListContainersResponse listContainersResponse = new ListContainersResponse(cmd.ResponseStream);
-                    List<CloudBlobContainer> containersList = listContainersResponse.Containers.Select(item => new CloudBlobContainer(item.Properties, item.Metadata, item.Name, this)).ToList();
-                    BlobContinuationToken continuationToken = null;
-                    if (listContainersResponse.NextMarker != null)
+                    continuationToken = new BlobContinuationToken()
                     {
-                        continuationToken = new BlobContinuationToken()
-                        {
-                            NextMarker = listContainersResponse.NextMarker,
-                            TargetLocation = cmd.CurrentResult.TargetLocation,
-                        };
-                    }
-
-                    return new ResultSegment<CloudBlobContainer>(containersList)
-                    {
-                        ContinuationToken = continuationToken,
+                        NextMarker = listContainersResponse.NextMarker,
+                        TargetLocation = cmd.CurrentResult.TargetLocation,
                     };
+                }
+
+                return Task.FromResult(new ResultSegment<CloudBlobContainer>(containersList)
+                {
+                    ContinuationToken = continuationToken,
                 });
             };
 
@@ -414,12 +408,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(
-                async () => await Executor.ExecuteAsync(
-                    this.GetServicePropertiesImpl(modifiedOptions),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                this.GetServicePropertiesImpl(modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private RESTCommand<ServiceProperties> GetServicePropertiesImpl(BlobRequestOptions requestOptions)
@@ -435,7 +428,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
             retCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task.Factory.StartNew(() => BlobHttpResponseParsers.ReadServiceProperties(cmd.ResponseStream));
+                return Task.FromResult(BlobHttpResponseParsers.ReadServiceProperties(cmd.ResponseStream));
             };
 
             requestOptions.ApplyToStorageCommand(retCmd);
@@ -479,11 +472,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(requestOptions, BlobType.Unspecified, this);
             operationContext = operationContext ?? new OperationContext();
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
-                 this.SetServicePropertiesImpl(properties, modifiedOptions),
+            return Executor.ExecuteAsyncNullReturn(
+                this.SetServicePropertiesImpl(properties, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         private RESTCommand<NullType> SetServicePropertiesImpl(ServiceProperties properties, BlobRequestOptions requestOptions)
@@ -546,12 +539,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(
-                async () => await Executor.ExecuteAsync(
-                    this.GetServiceStatsImpl(modifiedOptions),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                this.GetServiceStatsImpl(modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private RESTCommand<ServiceStats> GetServiceStatsImpl(BlobRequestOptions requestOptions)

--- a/Lib/WindowsRuntime/Blob/CloudBlobContainer.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlobContainer.cs
@@ -95,11 +95,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             }
 
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.CreateContainerImpl(modifiedOptions, accessType),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <returns><c>true</c> if the container did not already exist and was created; otherwise <c>false</c>.</returns>
         /// <remarks>This API requires Create or Write permissions.</remarks>
         [DoesServiceRequest]
-        public virtual Task<bool> CreateIfNotExistsAsync(BlobContainerPublicAccessType accessType, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<bool> CreateIfNotExistsAsync(BlobContainerPublicAccessType accessType, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             if (accessType == BlobContainerPublicAccessType.Unknown)
             {
@@ -160,34 +160,31 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () =>
+            try
             {
-                try
+                await this.CreateAsync(accessType, modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception)
+            {
+                if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Conflict)
                 {
-                    await this.CreateAsync(accessType, modifiedOptions, operationContext, cancellationToken);
-                    return true;
-                }
-                catch (Exception)
-                {
-                    if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Conflict)
+                    StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
+                    if ((extendedInfo == null) ||
+                        (extendedInfo.ErrorCode == BlobErrorCodeStrings.ContainerAlreadyExists))
                     {
-                        StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
-                        if ((extendedInfo == null) ||
-                            (extendedInfo.ErrorCode == BlobErrorCodeStrings.ContainerAlreadyExists))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            throw;
-                        }
+                        return false;
                     }
                     else
                     {
                         throw;
                     }
                 }
-            }, cancellationToken);
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         /// <summary>
@@ -226,11 +223,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task DeleteAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.DeleteContainerImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -265,55 +262,52 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns><c>true</c> if the container already existed and was deleted; otherwise, <c>false</c>.</returns>
         [DoesServiceRequest]
-        public virtual Task<bool> DeleteIfExistsAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<bool> DeleteIfExistsAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () =>
+            try
             {
-                try
+                bool exists = await this.ExistsAsync(true, modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                if (!exists)
                 {
-                    bool exists = await this.ExistsAsync(true, modifiedOptions, operationContext, cancellationToken);
-                    if (!exists)
+                    return false;
+                }
+            }
+            catch (StorageException e)
+            {
+                if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Forbidden)
+                {
+                    throw;
+                }
+            }
+
+            try
+            {
+                await this.DeleteAsync(accessCondition, modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception)
+            {
+                if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
+                    if ((extendedInfo == null) ||
+                        (extendedInfo.ErrorCode == BlobErrorCodeStrings.ContainerNotFound))
                     {
                         return false;
-                    }
-                }
-                catch (StorageException e)
-                {
-                    if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Forbidden)
-                    {
-                        throw;
-                    }
-                }
-
-                try
-                {
-                    await this.DeleteAsync(accessCondition, modifiedOptions, operationContext, cancellationToken);
-                    return true;
-                }
-                catch (Exception)
-                {
-                    if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
-                    {
-                        StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
-                        if ((extendedInfo == null) ||
-                            (extendedInfo.ErrorCode == BlobErrorCodeStrings.ContainerNotFound))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            throw;
-                        }
                     }
                     else
                     {
                         throw;
                     }
                 }
-            }, cancellationToken);
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         /// <summary>
@@ -421,19 +415,16 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A result segment containing objects that implement <see cref="IListBlobItem"/>.</returns>
         [DoesServiceRequest]
-        public virtual Task<BlobResultSegment> ListBlobsSegmentedAsync(string prefix, bool useFlatBlobListing, BlobListingDetails blobListingDetails, int? maxResults, BlobContinuationToken currentToken, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<BlobResultSegment> ListBlobsSegmentedAsync(string prefix, bool useFlatBlobListing, BlobListingDetails blobListingDetails, int? maxResults, BlobContinuationToken currentToken, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () =>
-            {
-                ResultSegment<IListBlobItem> resultSegment = await Executor.ExecuteAsync(
-                    this.ListBlobsImpl(prefix, maxResults, useFlatBlobListing, blobListingDetails, modifiedOptions, currentToken),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken);
+            ResultSegment<IListBlobItem> resultSegment = await Executor.ExecuteAsync(
+                this.ListBlobsImpl(prefix, maxResults, useFlatBlobListing, blobListingDetails, modifiedOptions, currentToken),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken).ConfigureAwait(false);
 
-                return new BlobResultSegment(resultSegment.Results, (BlobContinuationToken)resultSegment.ContinuationToken);
-            }, cancellationToken);
+            return new BlobResultSegment(resultSegment.Results, (BlobContinuationToken)resultSegment.ContinuationToken);
         }
 
         /// <summary>
@@ -474,11 +465,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task SetPermissionsAsync(BlobContainerPermissions permissions, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.SetPermissionsImpl(permissions, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -516,11 +507,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task<BlobContainerPermissions> GetPermissionsAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.GetPermissionsImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -561,11 +552,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         private Task<bool> ExistsAsync(bool primaryOnly, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.ExistsImpl(modifiedOptions, primaryOnly),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -603,11 +594,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task FetchAttributesAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.FetchAttributesImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -645,11 +636,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task SetMetadataAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.SetMetadataImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -699,11 +690,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task<string> AcquireLeaseAsync(TimeSpan? leaseTime, string proposedLeaseId, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.AcquireLeaseImpl(leaseTime, proposedLeaseId, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -742,11 +733,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task RenewLeaseAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.RenewLeaseImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -788,11 +779,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task<string> ChangeLeaseAsync(string proposedLeaseId, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.ChangeLeaseImpl(proposedLeaseId, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -831,11 +822,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task ReleaseLeaseAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.ReleaseLeaseImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -882,11 +873,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task<TimeSpan> BreakLeaseAsync(TimeSpan? breakPeriod, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.BreakLeaseImpl(breakPeriod, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1238,12 +1229,9 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
                 this.UpdateETagAndLastModified(resp);
-                return Task.Factory.StartNew(() =>
-                {
-                    ContainerHttpResponseParsers.ReadSharedAccessIdentifiers(cmd.ResponseStream, containerAcl);
-                    this.Properties.PublicAccess = containerAcl.PublicAccess;
-                    return containerAcl;
-                });
+                ContainerHttpResponseParsers.ReadSharedAccessIdentifiers(cmd.ResponseStream, containerAcl);
+                this.Properties.PublicAccess = containerAcl.PublicAccess;
+                return Task.FromResult(containerAcl);
             };
 
             return getCmd;
@@ -1322,24 +1310,21 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             getCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task.Factory.StartNew(() =>
+                ListBlobsResponse listBlobsResponse = new ListBlobsResponse(cmd.ResponseStream);
+                List<IListBlobItem> blobList = listBlobsResponse.Blobs.Select(item => this.SelectListBlobItem(item)).ToList();
+                BlobContinuationToken continuationToken = null;
+                if (listBlobsResponse.NextMarker != null)
                 {
-                    ListBlobsResponse listBlobsResponse = new ListBlobsResponse(cmd.ResponseStream);
-                    List<IListBlobItem> blobList = listBlobsResponse.Blobs.Select(item => this.SelectListBlobItem(item)).ToList();
-                    BlobContinuationToken continuationToken = null;
-                    if (listBlobsResponse.NextMarker != null)
+                    continuationToken = new BlobContinuationToken()
                     {
-                        continuationToken = new BlobContinuationToken()
-                        {
-                            NextMarker = listBlobsResponse.NextMarker,
-                            TargetLocation = cmd.CurrentResult.TargetLocation,
-                        };
-                    }
-
-                    return new ResultSegment<IListBlobItem>(blobList)
-                    {
-                        ContinuationToken = continuationToken,
+                        NextMarker = listBlobsResponse.NextMarker,
+                        TargetLocation = cmd.CurrentResult.TargetLocation,
                     };
+                }
+
+                return Task.FromResult(new ResultSegment<IListBlobItem>(blobList)
+                {
+                    ContinuationToken = continuationToken,
                 });
             };
 

--- a/Lib/WindowsRuntime/Blob/CloudBlockBlob.cs
+++ b/Lib/WindowsRuntime/Blob/CloudBlockBlob.cs
@@ -92,7 +92,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <para>To throw an exception if the blob exists instead of overwriting it, pass in an <see cref="AccessCondition"/>
         /// object generated using <see cref="AccessCondition.GenerateIfNotExistsCondition"/>.</para>
         /// </remarks>
-        public virtual Task<CloudBlobStream> OpenWriteAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<CloudBlobStream> OpenWriteAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             this.attributes.AssertNoSnapshot();
             operationContext = operationContext ?? new OperationContext();
@@ -100,43 +100,41 @@ namespace Microsoft.WindowsAzure.Storage.Blob
 
             if ((accessCondition != null) && accessCondition.IsConditional)
             {
-                return Task.Run(async () =>
+                try
                 {
-                    try
-                    {
-                        // If the accessCondition is IsIfNotExists, the fetch call will always return 400
-                        await this.FetchAttributesAsync(accessCondition.Clone().RemoveIsIfNotExistsCondition(), options, operationContext, cancellationToken);
+                    // If the accessCondition is IsIfNotExists, the fetch call will always return 400
+                    await this.FetchAttributesAsync(accessCondition.Clone().RemoveIsIfNotExistsCondition(), options, operationContext, cancellationToken).ConfigureAwait(false);
 
-                        // In case the blob already exists and the access condition is "IfNotExists", we should fail fast before uploading any content for the blob 
-                        if (accessCondition.IsIfNotExists)
-                        {
-                            throw GenerateExceptionForConflictFailure();
-                        }
-                    }
-                    catch (Exception)
+                    // In case the blob already exists and the access condition is "IfNotExists", we should fail fast before uploading any content for the blob 
+                    if (accessCondition.IsIfNotExists)
                     {
-                        if ((operationContext.LastResult != null) && 
-                            (((operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound) && 
-                            string.IsNullOrEmpty(accessCondition.IfMatchETag)) || 
-                            (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Forbidden)))
-                        {
-                            // If we got a 404 and the condition was not an If-Match OR if we got a 403,
-                            // we should continue with the operation.
-                        }
-                        else
-                        {
-                            throw;
-                        }
+                        throw GenerateExceptionForConflictFailure();
                     }
+                }
+                catch (Exception)
+                {
+                    if ((operationContext.LastResult != null) &&
+                        (((operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound) &&
+                          string.IsNullOrEmpty(accessCondition.IfMatchETag)) ||
+                         (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Forbidden)))
+                    {
+                        // If we got a 404 and the condition was not an If-Match OR if we got a 403,
+                        // we should continue with the operation.
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
 
-                    CloudBlobStream stream = new BlobWriteStream(this, accessCondition, modifiedOptions, operationContext);
-                    return stream;
-                }, cancellationToken);
+                CloudBlobStream stream = new BlobWriteStream(this, accessCondition, modifiedOptions, operationContext);
+                return stream;
+
             }
             else
             {
                 CloudBlobStream stream = new BlobWriteStream(this, accessCondition, modifiedOptions, operationContext);
-                return Task.FromResult(stream);
+                return stream;
             }
         }
 
@@ -249,7 +247,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A <see cref="Task"/> that represents an asynchronous action.</returns>
         [DoesServiceRequest]
-        internal Task UploadFromStreamAsyncHelper(Stream source, long? length, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        internal async Task UploadFromStreamAsyncHelper(Stream source, long? length, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             CommonUtility.AssertNotNull("source", source);
 
@@ -270,60 +268,58 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             operationContext = operationContext ?? new OperationContext();
             ExecutionState<NullType> tempExecutionState = CommonUtility.CreateTemporaryExecutionState(modifiedOptions);
 
-           return Task.Run(async () =>
+            bool lessThanSingleBlobThreshold = sourceAsStream.CanSeek
+                                               && (length ?? sourceAsStream.Length - sourceAsStream.Position)
+                                               <= modifiedOptions.SingleBlobUploadThresholdInBytes;
+            if (modifiedOptions.ParallelOperationThreadCount == 1 && lessThanSingleBlobThreshold)
             {
-                bool lessThanSingleBlobThreshold = sourceAsStream.CanSeek
-                                                   && (length ?? sourceAsStream.Length - sourceAsStream.Position)
-                                                   <= modifiedOptions.SingleBlobUploadThresholdInBytes;
-                if (modifiedOptions.ParallelOperationThreadCount == 1 && lessThanSingleBlobThreshold)
+                string contentMD5 = null;
+                if (modifiedOptions.StoreBlobContentMD5.Value)
                 {
-                    string contentMD5 = null;
-                    if (modifiedOptions.StoreBlobContentMD5.Value)
-                    {
-                        StreamDescriptor streamCopyState = new StreamDescriptor();
-                        long startPosition = sourceAsStream.Position;
-                        await sourceAsStream.WriteToAsync(Stream.Null, length, null /* maxLength */, true, tempExecutionState, streamCopyState, cancellationToken);
-                        sourceAsStream.Position = startPosition;
-                        contentMD5 = streamCopyState.Md5;
-                    }
-                    else
-                    {
-                        if (modifiedOptions.UseTransactionalMD5.Value)
-                        {
-                            throw new ArgumentException(SR.PutBlobNeedsStoreBlobContentMD5, "options");
-                        }
-                    }
-
-                    await Executor.ExecuteAsyncNullReturn(
-                        this.PutBlobImpl(sourceAsStream, length, contentMD5, accessCondition, modifiedOptions),
-                        modifiedOptions.RetryPolicy,
-                        operationContext,
-                        cancellationToken);
+                    StreamDescriptor streamCopyState = new StreamDescriptor();
+                    long startPosition = sourceAsStream.Position;
+                    await sourceAsStream.WriteToAsync(Stream.Null, length, null /* maxLength */, true, tempExecutionState, streamCopyState, cancellationToken).ConfigureAwait(false);
+                    sourceAsStream.Position = startPosition;
+                    contentMD5 = streamCopyState.Md5;
                 }
                 else
                 {
-                    bool useOpenWrite = !source.CanSeek
-                          || this.streamWriteSizeInBytes < Constants.MinLargeBlockSize
-                          || (modifiedOptions.StoreBlobContentMD5.HasValue && modifiedOptions.StoreBlobContentMD5.Value);
-
-                    if (useOpenWrite)
+                    if (modifiedOptions.UseTransactionalMD5.Value)
                     {
-                        using (CloudBlobStream blobStream = await this.OpenWriteAsync(accessCondition, options, operationContext, cancellationToken))
-                        {
-                            // We should always call AsStreamForWrite with bufferSize=0 to prevent buffering. Our
-                            // stream copier only writes 64K buffers at a time anyway, so no buffering is needed.
-                            await sourceAsStream.WriteToAsync(blobStream, length, null /* maxLength */, false, tempExecutionState, null /* streamCopyState */, cancellationToken);
-                            await blobStream.CommitAsync();
-                        }
-                    }
-                    else
-                    {
-                        // Synchronization mutex required to ensure thread-safe, concurrent operations on related SubStream instances.
-                        SemaphoreSlim streamReadThrottler = new SemaphoreSlim(1);
-                        await this.UploadFromMultiStreamAsync(this.OpenMultiSubStream(source, length, streamReadThrottler), accessCondition, modifiedOptions, operationContext, cancellationToken);
+                        throw new ArgumentException(SR.PutBlobNeedsStoreBlobContentMD5, "options");
                     }
                 }
-            }, cancellationToken);
+
+                await Executor.ExecuteAsyncNullReturn(
+                    this.PutBlobImpl(sourceAsStream, length, contentMD5, accessCondition, modifiedOptions),
+                    modifiedOptions.RetryPolicy,
+                    operationContext,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                bool useOpenWrite = !source.CanSeek
+                      || this.streamWriteSizeInBytes < Constants.MinLargeBlockSize
+                      || (modifiedOptions.StoreBlobContentMD5.HasValue && modifiedOptions.StoreBlobContentMD5.Value);
+
+                if (useOpenWrite)
+                {
+                    using (CloudBlobStream blobStream = await this.OpenWriteAsync(accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false))
+                    {
+                        // We should always call AsStreamForWrite with bufferSize=0 to prevent buffering. Our
+                        // stream copier only writes 64K buffers at a time anyway, so no buffering is needed.
+                        await sourceAsStream.WriteToAsync(blobStream, length, null /* maxLength */, false, tempExecutionState, null /* streamCopyState */, cancellationToken).ConfigureAwait(false);
+                        await blobStream.CommitAsync().ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    // Synchronization mutex required to ensure thread-safe, concurrent operations on related SubStream instances.
+                    SemaphoreSlim streamReadThrottler = new SemaphoreSlim(1);
+                    await this.UploadFromMultiStreamAsync(this.OpenMultiSubStream(source, length, streamReadThrottler), accessCondition, modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
         }
 
         /// <summary>
@@ -386,13 +382,10 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             CommonUtility.AssertNotNull("source", source);
 
-            return Task.Run(async () =>
+            using (IRandomAccessStreamWithContentType stream = await source.OpenReadAsync().AsTask(cancellationToken).ConfigureAwait(false))
             {
-                using (IRandomAccessStreamWithContentType stream = await source.OpenReadAsync().AsTask(cancellationToken))
-                {
-                    await this.UploadFromStreamAsync(stream.AsStream(), accessCondition, options, operationContext, cancellationToken);
-                }
-            });
+                await this.UploadFromStreamAsync(stream.AsStream(), accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false);
+            }
         }
 #endif
 
@@ -407,31 +400,28 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A <see cref="Task"/> that represents an asynchronous action.</returns>
         [DoesServiceRequest]
-        public virtual Task UploadFromFileAsync(string path, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task UploadFromFileAsync(string path, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
-            CommonUtility.AssertNotNull("path", path);   
-            
-            return Task.Run(async () =>
+            CommonUtility.AssertNotNull("path", path);
+
+            BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.BlockBlob, this.ServiceClient);
+
+            // Determines whether to use the normal, single-stream upload approach or the new parallel, multi-stream strategy.
+            bool useSingleStream = this.streamWriteSizeInBytes < Constants.MinLargeBlockSize
+                                   || (modifiedOptions.StoreBlobContentMD5.HasValue && modifiedOptions.StoreBlobContentMD5.Value);
+
+            if (useSingleStream)
             {
-                BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.BlockBlob, this.ServiceClient);
-
-                // Determines whether to use the normal, single-stream upload approach or the new parallel, multi-stream strategy.
-                bool useSingleStream = this.streamWriteSizeInBytes < Constants.MinLargeBlockSize 
-                    || (modifiedOptions.StoreBlobContentMD5.HasValue && modifiedOptions.StoreBlobContentMD5.Value); 
-
-                if (useSingleStream)
+                using (Stream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
                 {
-                    using (Stream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
-                    {
-                        await this.UploadFromStreamAsync(stream, accessCondition, modifiedOptions, operationContext, cancellationToken);
-                    }
+                    await this.UploadFromStreamAsync(stream, accessCondition, modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
                 }
-                else
-                {
-                    CheckAdjustBlockSize(new FileInfo(path).Length);
-                    await this.UploadFromMultiStreamAsync(OpenMultiFileStream(path), accessCondition, modifiedOptions, operationContext, cancellationToken);
-                }
-            }, cancellationToken);
+            }
+            else
+            {
+                CheckAdjustBlockSize(new FileInfo(path).Length);
+                await this.UploadFromMultiStreamAsync(OpenMultiFileStream(path), accessCondition, modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+            }
         }
 #endif
 
@@ -589,17 +579,14 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>The contents of the blob, as a string.</returns>
         [DoesServiceRequest]
-        public virtual Task<string> DownloadTextAsync(Encoding encoding, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<string> DownloadTextAsync(Encoding encoding, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
-            return Task.Run(async () =>
+            using (SyncMemoryStream stream = new SyncMemoryStream())
             {
-                using (SyncMemoryStream stream = new SyncMemoryStream())
-                {
-                    await this.DownloadToStreamAsync(stream, accessCondition, options, operationContext, cancellationToken);
-                    byte[] streamAsBytes = stream.ToArray();
-                    return (encoding ?? Encoding.UTF8).GetString(streamAsBytes, 0, streamAsBytes.Length);
-                }
-            }, cancellationToken);
+                await this.DownloadToStreamAsync(stream, accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false);
+                byte[] streamAsBytes = stream.ToArray();
+                return (encoding ?? Encoding.UTF8).GetString(streamAsBytes, 0, streamAsBytes.Length);
+            }
         }
 
         /// <summary>
@@ -640,11 +627,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             this.attributes.AssertNoSnapshot();
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.BlockBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.CreateSnapshotImpl(metadata, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -691,60 +678,57 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A <see cref="Task"/> that represents an asynchronous action.</returns>
         [DoesServiceRequest]
-        public virtual Task PutBlockAsync(string blockId, Stream blockData, string contentMD5, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task PutBlockAsync(string blockId, Stream blockData, string contentMD5, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.BlockBlob, this.ServiceClient);
             bool requiresContentMD5 = string.IsNullOrEmpty(contentMD5) && modifiedOptions.UseTransactionalMD5.Value;
             operationContext = operationContext ?? new OperationContext();
             ExecutionState<NullType> tempExecutionState = CommonUtility.CreateTemporaryExecutionState(modifiedOptions);
 
-            return Task.Run(async () =>
+            Stream blockDataAsStream = blockData;
+            Stream seekableStream = blockDataAsStream;
+            bool seekableStreamCreated = false;
+
+            try
             {
-                Stream blockDataAsStream = blockData;
-                Stream seekableStream = blockDataAsStream;
-                bool seekableStreamCreated = false;
-
-                try
+                if (!blockDataAsStream.CanSeek || requiresContentMD5)
                 {
-                    if (!blockDataAsStream.CanSeek || requiresContentMD5)
+                    Stream writeToStream;
+                    if (blockDataAsStream.CanSeek)
                     {
-                        Stream writeToStream;
-                        if (blockDataAsStream.CanSeek)
-                        {
-                            writeToStream = Stream.Null;
-                        }
-                        else
-                        {
-                            seekableStream = new MultiBufferMemoryStream(this.ServiceClient.BufferManager);
-                            seekableStreamCreated = true;
-                            writeToStream = seekableStream;
-                        }
-
-                        StreamDescriptor streamCopyState = new StreamDescriptor();
-                        long startPosition = seekableStream.Position;
-                        await blockDataAsStream.WriteToAsync(writeToStream, null /* copyLength */, Constants.MaxBlockSize, requiresContentMD5, tempExecutionState, streamCopyState, cancellationToken);
-                        seekableStream.Position = startPosition;
-
-                        if (requiresContentMD5)
-                        {
-                            contentMD5 = streamCopyState.Md5;
-                        }
+                        writeToStream = Stream.Null;
+                    }
+                    else
+                    {
+                        seekableStream = new MultiBufferMemoryStream(this.ServiceClient.BufferManager);
+                        seekableStreamCreated = true;
+                        writeToStream = seekableStream;
                     }
 
-                    await Executor.ExecuteAsyncNullReturn(
-                        this.PutBlockImpl(seekableStream, blockId, contentMD5, accessCondition, modifiedOptions),
-                        modifiedOptions.RetryPolicy,
-                        operationContext,
-                        cancellationToken);
-                }
-                finally
-                {
-                    if (seekableStreamCreated)
+                    StreamDescriptor streamCopyState = new StreamDescriptor();
+                    long startPosition = seekableStream.Position;
+                    await blockDataAsStream.WriteToAsync(writeToStream, null /* copyLength */, Constants.MaxBlockSize, requiresContentMD5, tempExecutionState, streamCopyState, cancellationToken).ConfigureAwait(false);
+                    seekableStream.Position = startPosition;
+
+                    if (requiresContentMD5)
                     {
-                        seekableStream.Dispose();
+                        contentMD5 = streamCopyState.Md5;
                     }
                 }
-            }, cancellationToken);
+
+                await Executor.ExecuteAsyncNullReturn(
+                    this.PutBlockImpl(seekableStream, blockId, contentMD5, accessCondition, modifiedOptions),
+                    modifiedOptions.RetryPolicy,
+                    operationContext,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (seekableStreamCreated)
+                {
+                    seekableStream.Dispose();
+                }
+            }
         }
 
         /// <summary>
@@ -786,11 +770,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.BlockBlob, this.ServiceClient);
             IEnumerable<PutBlockListItem> items = blockList.Select(i => new PutBlockListItem(i, BlockSearchMode.Latest));
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.PutBlockListImpl(items, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -832,11 +816,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task<IEnumerable<ListBlockItem>> DownloadBlockListAsync(BlockListingFilter blockListingFilter, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.BlockBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.GetBlockListImpl(blockListingFilter, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -988,11 +972,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             this.attributes.AssertNoSnapshot();
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.BlockBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.SetStandardBlobTierImpl(standardBlobTier, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1159,12 +1143,9 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, true);
-                return Task.Factory.StartNew(() =>
-                {
-                    GetBlockListResponse responseParser = new GetBlockListResponse(cmd.ResponseStream);
-                    IEnumerable<ListBlockItem> blocks = new List<ListBlockItem>(responseParser.Blocks);
-                    return blocks;
-                });
+                GetBlockListResponse responseParser = new GetBlockListResponse(cmd.ResponseStream);
+                IEnumerable<ListBlockItem> blocks = new List<ListBlockItem>(responseParser.Blocks);
+                return Task.FromResult(blocks);
             };
 
             return getCmd;

--- a/Lib/WindowsRuntime/Blob/CloudPageBlob.cs
+++ b/Lib/WindowsRuntime/Blob/CloudPageBlob.cs
@@ -107,7 +107,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// object generated using <see cref="AccessCondition.GenerateIfNotExistsCondition"/>.
         /// </remarks>
         [DoesServiceRequest]
-        internal virtual Task<CloudBlobStream> OpenWriteAsync(long? size, PremiumPageBlobTier? premiumPageBlobTier, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        internal virtual async Task<CloudBlobStream> OpenWriteAsync(long? size, PremiumPageBlobTier? premiumPageBlobTier, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             this.attributes.AssertNoSnapshot();
             bool createNew = size.HasValue;
@@ -117,26 +117,23 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 throw new ArgumentException(SR.MD5NotPossible);
             }
 
-            return Task.Run(async () =>
+            if (createNew)
             {
-                if (createNew)
-                {
-                    await this.CreateAsync(size.Value, premiumPageBlobTier, accessCondition, options, operationContext, cancellationToken);
-                }
-                else
-                {
-                    await this.FetchAttributesAsync(accessCondition, options, operationContext, cancellationToken);
-                    size = this.Properties.Length;
-                }
+                await this.CreateAsync(size.Value, premiumPageBlobTier, accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await this.FetchAttributesAsync(accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false);
+                size = this.Properties.Length;
+            }
 
-                if (accessCondition != null)
-                {
-                    accessCondition = AccessCondition.GenerateLeaseCondition(accessCondition.LeaseId);
-                }
+            if (accessCondition != null)
+            {
+                accessCondition = AccessCondition.GenerateLeaseCondition(accessCondition.LeaseId);
+            }
 
-                CloudBlobStream stream = new BlobWriteStream(this, size.Value, createNew, accessCondition, modifiedOptions, operationContext);
-                return stream;
-            }, cancellationToken);
+            CloudBlobStream stream = new BlobWriteStream(this, size.Value, createNew, accessCondition, modifiedOptions, operationContext);
+            return stream;
         }
 
         /// <summary>
@@ -281,7 +278,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A <see cref="Task"/> that represents an asynchronous action.</returns>
         [DoesServiceRequest]
-        internal Task UploadFromStreamAsyncHelper(Stream source, long? length, PremiumPageBlobTier? premiumPageBlobTier, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        internal async Task UploadFromStreamAsyncHelper(Stream source, long? length, PremiumPageBlobTier? premiumPageBlobTier, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             CommonUtility.AssertNotNull("source", source);
 
@@ -310,16 +307,13 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 throw new ArgumentException(SR.InvalidPageSize, "source");
             }
 
-            return Task.Run(async () =>
+            using (CloudBlobStream blobStream = await this.OpenWriteAsync(length, premiumPageBlobTier, accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false))
             {
-                using (CloudBlobStream blobStream = await this.OpenWriteAsync(length, premiumPageBlobTier, accessCondition, options, operationContext, cancellationToken))
-                {
-                    // We should always call AsStreamForWrite with bufferSize=0 to prevent buffering. Our
-                    // stream copier only writes 64K buffers at a time anyway, so no buffering is needed.
-                    await sourceAsStream.WriteToAsync(blobStream, length, null /* maxLength */, false, tempExecutionState, null /* streamCopyState */, cancellationToken);
-                    await blobStream.CommitAsync();
-                }
-            }, cancellationToken);
+                // We should always call AsStreamForWrite with bufferSize=0 to prevent buffering. Our
+                // stream copier only writes 64K buffers at a time anyway, so no buffering is needed.
+                await sourceAsStream.WriteToAsync(blobStream, length, null /* maxLength */, false, tempExecutionState, null /* streamCopyState */, cancellationToken).ConfigureAwait(false);
+                await blobStream.CommitAsync().ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -399,13 +393,10 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             CommonUtility.AssertNotNull("source", source);
 
-            return Task.Run(async () =>
+            using (IRandomAccessStreamWithContentType stream = await source.OpenReadAsync().AsTask(cancellationToken).ConfigureAwait(false))
             {
-                using (IRandomAccessStreamWithContentType stream = await source.OpenReadAsync().AsTask(cancellationToken))
-                {
-                    await this.UploadFromStreamAsync(stream.AsStream(), premiumBlobTier, accessCondition, options, operationContext, cancellationToken);
-                }
-            });
+                await this.UploadFromStreamAsync(stream.AsStream(), premiumBlobTier, accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false);
+            }
         }
 #endif
 #if NETCORE
@@ -435,17 +426,14 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A <see cref="Task"/> that represents an asynchronous action.</returns>
         [DoesServiceRequest]
-        public virtual Task UploadFromFileAsync(string path, PremiumPageBlobTier? premiumBlobTier, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task UploadFromFileAsync(string path, PremiumPageBlobTier? premiumBlobTier, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             CommonUtility.AssertNotNull("path", path);
 
-            return Task.Run(async () =>
+            using (Stream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
-                using (Stream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
-                {
-                    await this.UploadFromStreamAsync(stream, premiumBlobTier, accessCondition, options, operationContext, cancellationToken);
-                }
-            }, cancellationToken);
+                await this.UploadFromStreamAsync(stream, premiumBlobTier, accessCondition, options, operationContext, cancellationToken).ConfigureAwait(false);
+            }
         }
 #endif
 
@@ -574,11 +562,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task CreateAsync(long size, PremiumPageBlobTier? premiumBlobTier, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.CreateImpl(size, premiumBlobTier, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -619,11 +607,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task ResizeAsync(long size, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.ResizeImpl(size, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -667,11 +655,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task SetSequenceNumberAsync(SequenceNumberAction sequenceNumberAction, long? sequenceNumber, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.SetSequenceNumberImpl(sequenceNumberAction, sequenceNumber, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -713,11 +701,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task<IEnumerable<PageRange>> GetPageRangesAsync(long? offset, long? length, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.GetPageRangesImpl(offset, length, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -762,11 +750,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task<IEnumerable<PageDiffRange>> GetPageRangesDiffAsync(DateTimeOffset previousSnapshotTime, long? offset, long? length, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.GetPageRangesDiffImpl(previousSnapshotTime, offset, length, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -807,11 +795,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             this.attributes.AssertNoSnapshot();
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.CreateSnapshotImpl(metadata, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -858,59 +846,56 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A <see cref="Task"/> that represents an asynchronous action.</returns>
         [DoesServiceRequest]
-        public virtual Task WritePagesAsync(Stream pageData, long startOffset, string contentMD5, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task WritePagesAsync(Stream pageData, long startOffset, string contentMD5, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
             bool requiresContentMD5 = (contentMD5 == null) && modifiedOptions.UseTransactionalMD5.Value;
             operationContext = operationContext ?? new OperationContext();
             ExecutionState<NullType> tempExecutionState = CommonUtility.CreateTemporaryExecutionState(modifiedOptions);
-            return Task.Run(async () =>
+            Stream pageDataAsStream = pageData;
+            Stream seekableStream = pageDataAsStream;
+            bool seekableStreamCreated = false;
+
+            try
             {
-                Stream pageDataAsStream = pageData;
-                Stream seekableStream = pageDataAsStream;
-                bool seekableStreamCreated = false;
-
-                try
+                if (!pageDataAsStream.CanSeek || requiresContentMD5)
                 {
-                    if (!pageDataAsStream.CanSeek || requiresContentMD5)
+                    Stream writeToStream;
+                    if (pageDataAsStream.CanSeek)
                     {
-                        Stream writeToStream;
-                        if (pageDataAsStream.CanSeek)
-                        {
-                            writeToStream = Stream.Null;
-                        }
-                        else
-                        {
-                            seekableStream = new MultiBufferMemoryStream(this.ServiceClient.BufferManager);
-                            seekableStreamCreated = true;
-                            writeToStream = seekableStream;
-                        }
-
-                        StreamDescriptor streamCopyState = new StreamDescriptor();
-                        long startPosition = seekableStream.Position;
-                        await pageDataAsStream.WriteToAsync(writeToStream, null /* copyLength */, Constants.MaxBlockSize, requiresContentMD5, tempExecutionState, streamCopyState, cancellationToken);
-                        seekableStream.Position = startPosition;
-
-                        if (requiresContentMD5)
-                        {
-                            contentMD5 = streamCopyState.Md5;
-                        }
+                        writeToStream = Stream.Null;
+                    }
+                    else
+                    {
+                        seekableStream = new MultiBufferMemoryStream(this.ServiceClient.BufferManager);
+                        seekableStreamCreated = true;
+                        writeToStream = seekableStream;
                     }
 
-                    await Executor.ExecuteAsyncNullReturn(
-                        this.PutPageImpl(seekableStream, startOffset, contentMD5, accessCondition, modifiedOptions),
-                        modifiedOptions.RetryPolicy,
-                        operationContext,
-                        cancellationToken);
-                }
-                finally
-                {
-                    if (seekableStreamCreated)
+                    StreamDescriptor streamCopyState = new StreamDescriptor();
+                    long startPosition = seekableStream.Position;
+                    await pageDataAsStream.WriteToAsync(writeToStream, null /* copyLength */, Constants.MaxBlockSize, requiresContentMD5, tempExecutionState, streamCopyState, cancellationToken).ConfigureAwait(false);
+                    seekableStream.Position = startPosition;
+
+                    if (requiresContentMD5)
                     {
-                        seekableStream.Dispose();
+                        contentMD5 = streamCopyState.Md5;
                     }
                 }
-            }, cancellationToken);
+
+                await Executor.ExecuteAsyncNullReturn(
+                    this.PutPageImpl(seekableStream, startOffset, contentMD5, accessCondition, modifiedOptions),
+                    modifiedOptions.RetryPolicy,
+                    operationContext,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (seekableStreamCreated)
+                {
+                    seekableStream.Dispose();
+                }
+            }
         }
 
         /// <summary>
@@ -954,11 +939,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         public virtual Task ClearPagesAsync(long startOffset, long length, AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.ClearPageImpl(startOffset, length, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1103,11 +1088,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             CommonUtility.AssertNotNull("sourceSnapshot", sourceSnapshot);
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.Unspecified, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.StartCopyImpl(this.attributes, sourceSnapshot, true /*incrementalCopy */, null /* pageBlobTier */, null /* sourceAccessCondition */, destAccessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1147,11 +1132,11 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         {
             this.attributes.AssertNoSnapshot();
             BlobRequestOptions modifiedOptions = BlobRequestOptions.ApplyDefaults(options, BlobType.PageBlob, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.SetBlobTierImpl(premiumBlobTier, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -1302,12 +1287,9 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, true);
-                return Task.Factory.StartNew(() =>
-                {
-                    GetPageRangesResponse getPageRangesResponse = new GetPageRangesResponse(cmd.ResponseStream);
-                    IEnumerable<PageRange> pageRanges = new List<PageRange>(getPageRangesResponse.PageRanges);
-                    return pageRanges;
-                });
+                GetPageRangesResponse getPageRangesResponse = new GetPageRangesResponse(cmd.ResponseStream);
+                IEnumerable<PageRange> pageRanges = new List<PageRange>(getPageRangesResponse.PageRanges);
+                return Task.FromResult(pageRanges);
             };
 
             return getCmd;
@@ -1339,12 +1321,9 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
                 CloudBlob.UpdateETagLMTLengthAndSequenceNumber(this.attributes, resp, true);
-                return Task.Factory.StartNew(() =>
-                {
-                    GetPageDiffRangesResponse getPageDiffRangesResponse = new GetPageDiffRangesResponse(cmd.ResponseStream);
-                    IEnumerable<PageDiffRange> pageDiffRanges = new List<PageDiffRange>(getPageDiffRangesResponse.PageDiffRanges);
-                    return pageDiffRanges;
-                });
+                GetPageDiffRangesResponse getPageDiffRangesResponse = new GetPageDiffRangesResponse(cmd.ResponseStream);
+                IEnumerable<PageDiffRange> pageDiffRanges = new List<PageDiffRange>(getPageDiffRangesResponse.PageDiffRanges);
+                return Task.FromResult(pageDiffRanges);
             };
 
             return getCmd;

--- a/Lib/WindowsRuntime/Core/Executor/Executor.cs
+++ b/Lib/WindowsRuntime/Core/Executor/Executor.cs
@@ -130,14 +130,14 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
                         // Send Request 
                         executionState.CurrentOperation = ExecutorOperation.BeginGetResponse;
                         Logger.LogInformational(executionState.OperationContext, SR.TraceGetResponse);
-                        executionState.Resp = await client.SendAsync(executionState.Req, HttpCompletionOption.ResponseHeadersRead, timeoutTokenSource.Token);
+                        executionState.Resp = await client.SendAsync(executionState.Req, HttpCompletionOption.ResponseHeadersRead, timeoutTokenSource.Token).ConfigureAwait(false);
                         executionState.CurrentOperation = ExecutorOperation.EndGetResponse;
 
                         // Since HttpClient wont throw for non success, manually check and populate an exception
                         if (!executionState.Resp.IsSuccessStatusCode)
                         {
                             // At this point, don't try to read the stream to parse the error
-                            executionState.ExceptionRef = await Exceptions.PopulateStorageExceptionFromHttpResponseMessage(executionState.Resp, executionState.Cmd.CurrentResult, executionState.Cmd.ParseError);
+                            executionState.ExceptionRef = await Exceptions.PopulateStorageExceptionFromHttpResponseMessage(executionState.Resp, executionState.Cmd.CurrentResult, executionState.Cmd.ParseError).ConfigureAwait(false);
                         }
 
                         Logger.LogInformational(executionState.OperationContext, SR.TraceResponse, executionState.Cmd.CurrentResult.HttpStatusCode, executionState.Cmd.CurrentResult.ServiceRequestID, executionState.Cmd.CurrentResult.ContentMd5, executionState.Cmd.CurrentResult.Etag);
@@ -165,7 +165,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
 
                         // 8. (Potentially reads stream from server)
                         executionState.CurrentOperation = ExecutorOperation.GetResponseStream;
-                        cmd.ResponseStream = await executionState.Resp.Content.ReadAsStreamAsync();
+                        cmd.ResponseStream = await executionState.Resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
                         // The stream is now available in ResponseStream. Use the stream to parse out the response or error
                         if (executionState.ExceptionRef != null)
@@ -176,7 +176,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
                             try
                             {
                                 cmd.ErrorStream = new MemoryStream();
-                                await cmd.ResponseStream.WriteToAsync(cmd.ErrorStream, null /* copyLength */, null /* maxLength */, false, executionState, new StreamDescriptor(), timeoutTokenSource.Token);
+                                await cmd.ResponseStream.WriteToAsync(cmd.ErrorStream, null /* copyLength */, null /* maxLength */, false, executionState, new StreamDescriptor(), timeoutTokenSource.Token).ConfigureAwait(false);
                                 cmd.ErrorStream.Seek(0, SeekOrigin.Begin);
 #if NETCORE
                                 executionState.ExceptionRef = StorageException.TranslateExceptionWithPreBufferedStream(executionState.ExceptionRef, executionState.Cmd.CurrentResult, stream => executionState.Cmd.ParseError(stream, executionState.Resp, null), cmd.ErrorStream, executionState.Resp);
@@ -212,7 +212,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
                                 {
                                     executionState.CurrentOperation = ExecutorOperation.BeginDownloadResponse;
                                     Logger.LogInformational(executionState.OperationContext, SR.TraceDownload);
-                                    await cmd.ResponseStream.WriteToAsync(cmd.DestinationStream, null /* copyLength */, null /* maxLength */, cmd.CalculateMd5ForResponseStream, executionState, cmd.StreamCopyState, timeoutTokenSource.Token);
+                                    await cmd.ResponseStream.WriteToAsync(cmd.DestinationStream, null /* copyLength */, null /* maxLength */, cmd.CalculateMd5ForResponseStream, executionState, cmd.StreamCopyState, timeoutTokenSource.Token).ConfigureAwait(false);
                                 }
                                 finally
                                 {
@@ -227,7 +227,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
                         {
                             executionState.CurrentOperation = ExecutorOperation.PostProcess;
                             Logger.LogInformational(executionState.OperationContext, SR.TracePostProcess);
-                            executionState.Result = await cmd.PostProcessResponse(cmd, executionState.Resp, executionState.OperationContext);
+                            executionState.Result = await cmd.PostProcessResponse(cmd, executionState.Resp, executionState.OperationContext).ConfigureAwait(false);
                         }
 
                         executionState.CurrentOperation = ExecutorOperation.EndOperation;
@@ -320,7 +320,7 @@ namespace Microsoft.WindowsAzure.Storage.Core.Executor
 
                         if (delay > TimeSpan.Zero)
                         {
-                            await Task.Delay(delay, token);
+                            await Task.Delay(delay, token).ConfigureAwait(false);
                         }
 
                         Logger.LogInformational(executionState.OperationContext, SR.TraceRetry);

--- a/Lib/WindowsRuntime/File/CloudFileClient.cs
+++ b/Lib/WindowsRuntime/File/CloudFileClient.cs
@@ -105,19 +105,16 @@ namespace Microsoft.WindowsAzure.Storage.File
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A result segment of shares.</returns>
         [DoesServiceRequest]
-        public virtual Task<ShareResultSegment> ListSharesSegmentedAsync(string prefix, ShareListingDetails detailsIncluded, int? maxResults, FileContinuationToken currentToken, FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<ShareResultSegment> ListSharesSegmentedAsync(string prefix, ShareListingDetails detailsIncluded, int? maxResults, FileContinuationToken currentToken, FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
-            return Task.Run(async () =>
-            {
-                FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this);
-                ResultSegment<CloudFileShare> resultSegment = await Executor.ExecuteAsync(
-                    this.ListSharesImpl(prefix, detailsIncluded, currentToken, maxResults, modifiedOptions),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken);
+            FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this);
+            ResultSegment<CloudFileShare> resultSegment = await Executor.ExecuteAsync(
+                this.ListSharesImpl(prefix, detailsIncluded, currentToken, maxResults, modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken).ConfigureAwait(false);
 
-                return new ShareResultSegment(resultSegment.Results, (FileContinuationToken)resultSegment.ContinuationToken);
-            }, cancellationToken);
+            return new ShareResultSegment(resultSegment.Results, (FileContinuationToken)resultSegment.ContinuationToken);
         }
 
         /// <summary>
@@ -155,12 +152,11 @@ namespace Microsoft.WindowsAzure.Storage.File
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(
-                async () => await Executor.ExecuteAsync(
-                    this.GetServicePropertiesImpl(modifiedOptions),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                this.GetServicePropertiesImpl(modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         /// <summary>
@@ -200,11 +196,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         {
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(requestOptions, this);
             operationContext = operationContext ?? new OperationContext();
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
-                 this.SetServicePropertiesImpl(properties, modifiedOptions),
+            return Executor.ExecuteAsyncNullReturn(
+                this.SetServicePropertiesImpl(properties, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -232,25 +228,22 @@ namespace Microsoft.WindowsAzure.Storage.File
             getCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null, cmd, ex);
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task.Factory.StartNew(() =>
+                ListSharesResponse listSharesResponse = new ListSharesResponse(cmd.ResponseStream);
+                List<CloudFileShare> sharesList = listSharesResponse.Shares.Select(item => new CloudFileShare(item.Properties, item.Metadata, item.Name, item.SnapshotTime, this)).ToList();
+                FileContinuationToken continuationToken = null;
+                if (listSharesResponse.NextMarker != null)
+                {
+                    continuationToken = new FileContinuationToken()
                     {
-                        ListSharesResponse listSharesResponse = new ListSharesResponse(cmd.ResponseStream);
-                        List<CloudFileShare> sharesList = listSharesResponse.Shares.Select(item => new CloudFileShare(item.Properties, item.Metadata, item.Name, item.SnapshotTime, this)).ToList();
-                        FileContinuationToken continuationToken = null;
-                        if (listSharesResponse.NextMarker != null)
-                        {
-                            continuationToken = new FileContinuationToken()
-                            {
-                                NextMarker = listSharesResponse.NextMarker,
-                                TargetLocation = cmd.CurrentResult.TargetLocation,
-                            };
-                        }
+                        NextMarker = listSharesResponse.NextMarker,
+                        TargetLocation = cmd.CurrentResult.TargetLocation,
+                    };
+                }
 
-                        return new ResultSegment<CloudFileShare>(sharesList)
-                        {
-                            ContinuationToken = continuationToken,
-                        };
-                    });
+                return Task.FromResult(new ResultSegment<CloudFileShare>(sharesList)
+                {
+                    ContinuationToken = continuationToken,
+                });
             };
 
             return getCmd;
@@ -269,7 +262,7 @@ namespace Microsoft.WindowsAzure.Storage.File
 
             retCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task.Factory.StartNew(() => FileHttpResponseParsers.ReadServiceProperties(cmd.ResponseStream));
+                return Task.FromResult(FileHttpResponseParsers.ReadServiceProperties(cmd.ResponseStream));
             };
 
             requestOptions.ApplyToStorageCommand(retCmd);

--- a/Lib/WindowsRuntime/File/CloudFileShare.cs
+++ b/Lib/WindowsRuntime/File/CloudFileShare.cs
@@ -72,11 +72,11 @@ namespace Microsoft.WindowsAzure.Storage.File
             }
 
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.CreateShareImpl(modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Microsoft.WindowsAzure.Storage.File
         /// <returns><c>true</c> if the share did not already exist and was created; otherwise <c>false</c>.</returns>
         /// <remarks>This API requires Create or Write permissions.</remarks>
         [DoesServiceRequest]
-        public virtual Task<bool> CreateIfNotExistsAsync(FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<bool> CreateIfNotExistsAsync(FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             this.AssertNoSnapshot();
             if (this.Properties.Quota.HasValue)
@@ -123,34 +123,31 @@ namespace Microsoft.WindowsAzure.Storage.File
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () =>
+            try
             {
-                try
+                await this.CreateAsync(modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception)
+            {
+                if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Conflict)
                 {
-                    await this.CreateAsync(modifiedOptions, operationContext, cancellationToken);
-                    return true;
-                }
-                catch (Exception)
-                {
-                    if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Conflict)
+                    StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
+                    if ((extendedInfo == null) ||
+                        (extendedInfo.ErrorCode == FileErrorCodeStrings.ShareAlreadyExists))
                     {
-                        StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
-                        if ((extendedInfo == null) ||
-                            (extendedInfo.ErrorCode == FileErrorCodeStrings.ShareAlreadyExists))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            throw;
-                        }
+                        return false;
                     }
                     else
                     {
                         throw;
                     }
                 }
-            }, cancellationToken);
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         /// <summary>
@@ -201,11 +198,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         public virtual Task<CloudFileShare> SnapshotAsync(IDictionary<string, string> metadata, AccessCondition accessCondition, FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync<CloudFileShare>(
+            return Executor.ExecuteAsync<CloudFileShare>(
                 this.SnapshotImpl(metadata, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -254,11 +251,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         public virtual Task DeleteAsync(DeleteShareSnapshotsOption deleteSnapshotsOption, AccessCondition accessCondition, FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.DeleteShareImpl(deleteSnapshotsOption, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -306,55 +303,52 @@ namespace Microsoft.WindowsAzure.Storage.File
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns><c>true</c> if the share already existed and was deleted; otherwise, <c>false</c>.</returns>
         [DoesServiceRequest]
-        public virtual Task<bool> DeleteIfExistsAsync(DeleteShareSnapshotsOption deleteSnapshotsOption, AccessCondition accessCondition, FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<bool> DeleteIfExistsAsync(DeleteShareSnapshotsOption deleteSnapshotsOption, AccessCondition accessCondition, FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () =>
+            try
             {
-                try
+                bool exists = await this.ExistsAsync(modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                if (!exists)
                 {
-                    bool exists = await this.ExistsAsync(modifiedOptions, operationContext, cancellationToken);
-                    if (!exists)
+                    return false;
+                }
+            }
+            catch (StorageException e)
+            {
+                if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Forbidden)
+                {
+                    throw;
+                }
+            }
+
+            try
+            {
+                await this.DeleteAsync(deleteSnapshotsOption, accessCondition, modifiedOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception)
+            {
+                if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
+                    if ((extendedInfo == null) ||
+                        (extendedInfo.ErrorCode == FileErrorCodeStrings.ShareNotFound))
                     {
                         return false;
-                    }
-                }
-                catch (StorageException e)
-                {
-                    if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Forbidden)
-                    {
-                        throw;
-                    }
-                }
-
-                try
-                {
-                    await this.DeleteAsync(deleteSnapshotsOption, accessCondition, modifiedOptions, operationContext, cancellationToken);
-                    return true;
-                }
-                catch (Exception)
-                {
-                    if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
-                    {
-                        StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
-                        if ((extendedInfo == null) ||
-                            (extendedInfo.ErrorCode == FileErrorCodeStrings.ShareNotFound))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            throw;
-                        }
                     }
                     else
                     {
                         throw;
                     }
                 }
-            }, cancellationToken);
+                else
+                {
+                    throw;
+                }
+            }
         }
 
         /// <summary>
@@ -391,11 +385,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         public virtual Task<bool> ExistsAsync(FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync(
+            return Executor.ExecuteAsync(
                 this.ExistsImpl(modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -433,11 +427,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         public virtual Task FetchAttributesAsync(AccessCondition accessCondition, FileRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.FetchAttributesImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -479,11 +473,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         {
             this.AssertNoSnapshot();
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.SetPermissionsImpl(permissions, accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -526,11 +520,11 @@ namespace Microsoft.WindowsAzure.Storage.File
             }
 
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.SetPropertiesImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -568,11 +562,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         {
             this.AssertNoSnapshot();
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync<FileSharePermissions>(
+            return Executor.ExecuteAsync<FileSharePermissions>(
                 this.GetPermissionsImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -608,11 +602,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         {
             this.AssertNoSnapshot();
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsync<ShareStats>(
+            return Executor.ExecuteAsync<ShareStats>(
                 this.GetStatsImpl(modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -648,11 +642,11 @@ namespace Microsoft.WindowsAzure.Storage.File
         {
             this.AssertNoSnapshot();
             FileRequestOptions modifiedOptions = FileRequestOptions.ApplyDefaults(options, this.ServiceClient);
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
+            return Executor.ExecuteAsyncNullReturn(
                 this.SetMetadataImpl(accessCondition, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         /// <summary>
@@ -841,11 +835,8 @@ namespace Microsoft.WindowsAzure.Storage.File
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
                 this.UpdateETagAndLastModified(resp);
-                return Task.Factory.StartNew(() =>
-                {
-                    ShareHttpResponseParsers.ReadSharedAccessIdentifiers(cmd.ResponseStream, shareAcl);
-                    return shareAcl;
-                });
+                ShareHttpResponseParsers.ReadSharedAccessIdentifiers(cmd.ResponseStream, shareAcl);
+                return Task.FromResult(shareAcl);
             };
 
             return getCmd;
@@ -864,7 +855,7 @@ namespace Microsoft.WindowsAzure.Storage.File
             retCmd.BuildRequest = (cmd, uri, builder, cnt, serverTimeout, ctx) => ShareHttpRequestMessageFactory.GetStats(uri, serverTimeout, ctx, this.ServiceClient.GetCanonicalizer(), this.ServiceClient.Credentials);
             retCmd.RetrieveResponseStream = true;
             retCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
-            retCmd.PostProcessResponse = (cmd, resp, ctx) => Task.Factory.StartNew(() => ShareHttpResponseParsers.ReadShareStats(cmd.ResponseStream));
+            retCmd.PostProcessResponse = (cmd, resp, ctx) => Task.FromResult(ShareHttpResponseParsers.ReadShareStats(cmd.ResponseStream));
             return retCmd;
         }
 

--- a/Lib/WindowsRuntime/File/FileReadStream.cs
+++ b/Lib/WindowsRuntime/File/FileReadStream.cs
@@ -96,7 +96,7 @@ namespace Microsoft.WindowsAzure.Storage.File
         /// <param name="count">The maximum number of bytes to read.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous read operation.</returns>
-        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CommonUtility.AssertNotNull("buffer", buffer);
             CommonUtility.AssertInBounds("offset", offset, 0, buffer.Length);
@@ -109,16 +109,16 @@ namespace Microsoft.WindowsAzure.Storage.File
 
             if ((this.currentOffset == this.Length) || (count == 0))
             {
-                return 0;
+                return Task.FromResult(0);
             }
 
             int readCount = this.ConsumeBuffer(buffer, offset, count);
             if (readCount > 0)
             {
-                return readCount;
+                return Task.FromResult(readCount);
             }
 
-            return await this.DispatchReadASync(buffer, offset, count);
+            return this.DispatchReadASync(buffer, offset, count);
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace Microsoft.WindowsAzure.Storage.File
                     this.GetReadSize(),
                     null /* accessCondition */,
                     this.options,
-                    this.operationContext);
+                    this.operationContext).ConfigureAwait(false);
 
                 if (!this.file.Properties.ETag.Equals(this.accessCondition.IfMatchETag, StringComparison.Ordinal))
                 {

--- a/Lib/WindowsRuntime/File/FileWriteStream.cs
+++ b/Lib/WindowsRuntime/File/FileWriteStream.cs
@@ -130,7 +130,7 @@ namespace Microsoft.WindowsAzure.Storage.File
 
                 if (bytesToWrite == maxBytesToWrite)
                 {
-                    await this.DispatchWriteAsync();
+                    await this.DispatchWriteAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -160,7 +160,7 @@ namespace Microsoft.WindowsAzure.Storage.File
                 throw this.lastException;
             }
 
-            await this.DispatchWriteAsync();
+            await this.DispatchWriteAsync().ConfigureAwait(false);
             await Task.Run(() => this.noPendingWritesEvent.Wait(), cancellationToken);
 
             if (this.lastException != null)
@@ -197,7 +197,7 @@ namespace Microsoft.WindowsAzure.Storage.File
         /// <returns>A task that represents the asynchronous commit operation.</returns>
         public override async Task CommitAsync()
         {
-            await this.FlushAsync();
+            await this.FlushAsync().ConfigureAwait(false);
             this.committed = true;
 
             try
@@ -205,7 +205,7 @@ namespace Microsoft.WindowsAzure.Storage.File
                 if (this.fileMD5 != null)
                 {
                     this.file.Properties.ContentMD5 = this.fileMD5.ComputeHash();
-                    await this.file.SetPropertiesAsync(this.accessCondition, this.options, this.operationContext);
+                    await this.file.SetPropertiesAsync(this.accessCondition, this.options, this.operationContext).ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -240,7 +240,7 @@ namespace Microsoft.WindowsAzure.Storage.File
 
             long offset = this.currentFileOffset;
             this.currentFileOffset += bufferToUpload.Length;
-            await this.WriteRangeAsync(bufferToUpload, offset, bufferMD5);
+            await this.WriteRangeAsync(bufferToUpload, offset, bufferMD5).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Microsoft.WindowsAzure.Storage.File
         private async Task WriteRangeAsync(Stream rangeData, long offset, string contentMD5)
         {
             this.noPendingWritesEvent.Increment();
-            await this.parallelOperationSemaphore.WaitAsync();
+            await this.parallelOperationSemaphore.WaitAsync().ConfigureAwait(false);
             Task writePagesTask = this.file.WriteRangeAsync(rangeData, offset, contentMD5, this.accessCondition, this.options, this.operationContext).ContinueWith(task =>
             {
                 if (task.Exception != null)

--- a/Lib/WindowsRuntime/Queue/CloudQueueClient.cs
+++ b/Lib/WindowsRuntime/Queue/CloudQueueClient.cs
@@ -226,7 +226,7 @@ namespace Microsoft.WindowsAzure.Storage.Queue
                 HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
             retCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task.Factory.StartNew(() => QueueHttpResponseParsers.ReadServiceProperties(cmd.ResponseStream));
+                return Task.FromResult(QueueHttpResponseParsers.ReadServiceProperties(cmd.ResponseStream));
             };
 
             requestOptions.ApplyToStorageCommand(retCmd);
@@ -356,7 +356,7 @@ namespace Microsoft.WindowsAzure.Storage.Queue
             retCmd.BuildRequest = (cmd, uri, builder, cnt, serverTimeout, ctx) => QueueHttpRequestMessageFactory.GetServiceStats(uri, serverTimeout, ctx, this.GetCanonicalizer(), this.Credentials);
             retCmd.RetrieveResponseStream = true;
             retCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
-            retCmd.PostProcessResponse = (cmd, resp, ctx) => Task.Factory.StartNew(() => QueueHttpResponseParsers.ReadServiceStats(cmd.ResponseStream));
+            retCmd.PostProcessResponse = (cmd, resp, ctx) => Task.FromResult(QueueHttpResponseParsers.ReadServiceStats(cmd.ResponseStream));
             return retCmd;
         }
 

--- a/Lib/WindowsRuntime/Queue/CloudQueueClient.cs
+++ b/Lib/WindowsRuntime/Queue/CloudQueueClient.cs
@@ -109,21 +109,18 @@ namespace Microsoft.WindowsAzure.Storage.Queue
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>A result segment of queues.</returns>
         [DoesServiceRequest]
-        public virtual Task<QueueResultSegment> ListQueuesSegmentedAsync(string prefix, QueueListingDetails detailsIncluded, int? maxResults, QueueContinuationToken currentToken, QueueRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<QueueResultSegment> ListQueuesSegmentedAsync(string prefix, QueueListingDetails detailsIncluded, int? maxResults, QueueContinuationToken currentToken, QueueRequestOptions options, OperationContext operationContext, CancellationToken cancellationToken)
         {
             QueueRequestOptions modifiedOptions = QueueRequestOptions.ApplyDefaults(options, this);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () =>
-            {
-                ResultSegment<CloudQueue> resultSegment = await Executor.ExecuteAsync(
-                    this.ListQueuesImpl(prefix, maxResults, detailsIncluded, modifiedOptions, currentToken),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken);
+            ResultSegment<CloudQueue> resultSegment = await Executor.ExecuteAsync(
+                this.ListQueuesImpl(prefix, maxResults, detailsIncluded, modifiedOptions, currentToken),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken).ConfigureAwait(false);
 
-                return new QueueResultSegment(resultSegment.Results, (QueueContinuationToken)resultSegment.ContinuationToken);
-            }, cancellationToken);
+            return new QueueResultSegment(resultSegment.Results, (QueueContinuationToken)resultSegment.ContinuationToken);
         }
 
         /// <summary>
@@ -151,26 +148,23 @@ namespace Microsoft.WindowsAzure.Storage.Queue
             getCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task.Factory.StartNew(() =>
+                ListQueuesResponse listQueuesResponse = new ListQueuesResponse(cmd.ResponseStream);
+
+                List<CloudQueue> queuesList = listQueuesResponse.Queues.Select(item => new CloudQueue(item.Metadata, item.Name, this)).ToList();
+
+                QueueContinuationToken continuationToken = null;
+                if (listQueuesResponse.NextMarker != null)
                 {
-                    ListQueuesResponse listQueuesResponse = new ListQueuesResponse(cmd.ResponseStream);
-
-                    List<CloudQueue> queuesList = listQueuesResponse.Queues.Select(item => new CloudQueue(item.Metadata, item.Name, this)).ToList();
-
-                    QueueContinuationToken continuationToken = null;
-                    if (listQueuesResponse.NextMarker != null)
+                    continuationToken = new QueueContinuationToken()
                     {
-                        continuationToken = new QueueContinuationToken()
-                        {
-                            NextMarker = listQueuesResponse.NextMarker,
-                            TargetLocation = cmd.CurrentResult.TargetLocation,
-                        };
-                    }
-
-                    return new ResultSegment<CloudQueue>(queuesList)
-                    {
-                        ContinuationToken = continuationToken,
+                        NextMarker = listQueuesResponse.NextMarker,
+                        TargetLocation = cmd.CurrentResult.TargetLocation,
                     };
+                }
+
+                return Task.FromResult(new ResultSegment<CloudQueue>(queuesList)
+                {
+                    ContinuationToken = continuationToken,
                 });
             };
 
@@ -214,11 +208,11 @@ namespace Microsoft.WindowsAzure.Storage.Queue
             QueueRequestOptions modifiedOptions = QueueRequestOptions.ApplyDefaults(options, this);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () => await Executor.ExecuteAsync(
-              this.GetServicePropertiesImpl(modifiedOptions),
-              modifiedOptions.RetryPolicy,
-              operationContext,
-              cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                this.GetServicePropertiesImpl(modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private RESTCommand<ServiceProperties> GetServicePropertiesImpl(QueueRequestOptions requestOptions)
@@ -276,11 +270,11 @@ namespace Microsoft.WindowsAzure.Storage.Queue
         {
             QueueRequestOptions modifiedOptions = QueueRequestOptions.ApplyDefaults(requestOptions, this);
             operationContext = operationContext ?? new OperationContext();
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
-                 this.SetServicePropertiesImpl(properties, modifiedOptions),
+            return Executor.ExecuteAsyncNullReturn(
+                this.SetServicePropertiesImpl(properties, modifiedOptions),
                 modifiedOptions.RetryPolicy,
                 operationContext,
-                cancellationToken), cancellationToken);
+                cancellationToken);
         }
 
         private RESTCommand<NullType> SetServicePropertiesImpl(ServiceProperties properties, QueueRequestOptions requestOptions)
@@ -342,12 +336,11 @@ namespace Microsoft.WindowsAzure.Storage.Queue
             QueueRequestOptions modifiedOptions = QueueRequestOptions.ApplyDefaults(options, this);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(
-                async () => await Executor.ExecuteAsync(
-                    this.GetServiceStatsImpl(modifiedOptions),
-                    modifiedOptions.RetryPolicy,
-                    operationContext,
-                    cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                this.GetServiceStatsImpl(modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private RESTCommand<ServiceStats> GetServiceStatsImpl(QueueRequestOptions requestOptions)

--- a/Lib/WindowsRuntime/Table/CloudTable.cs
+++ b/Lib/WindowsRuntime/Table/CloudTable.cs
@@ -257,39 +257,36 @@ namespace Microsoft.WindowsAzure.Storage.Table
         /// <returns><c>true</c> if table was created; otherwise, <c>false</c>.</returns>
         /// <remarks>This API performs an existence check and therefore requires list permissions.</remarks>
         [DoesServiceRequest]
-        public virtual Task<bool> CreateIfNotExistsAsync(TableRequestOptions requestOptions, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<bool> CreateIfNotExistsAsync(TableRequestOptions requestOptions, OperationContext operationContext, CancellationToken cancellationToken)
         {
             requestOptions = TableRequestOptions.ApplyDefaults(requestOptions, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () =>
+            try
             {
-                try
+                await this.CreateAsync(requestOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception)
+            {
+                if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Conflict)
                 {
-                    await this.CreateAsync(requestOptions, operationContext, cancellationToken);
-                    return true;
-                }
-                catch (Exception)
-                {
-                    if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.Conflict)
+                    StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
+                    if ((extendedInfo == null) ||
+                        (extendedInfo.ErrorCode == TableErrorCodeStrings.TableAlreadyExists))
                     {
-                        StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
-                        if ((extendedInfo == null) ||
-                            (extendedInfo.ErrorCode == TableErrorCodeStrings.TableAlreadyExists))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            throw;
-                        }
+                        return false;
                     }
                     else
                     {
                         throw;
                     }
                 }
-            }, cancellationToken);
+                else
+                {
+                    throw;
+                }
+            }
         }
         #endregion
 
@@ -371,54 +368,51 @@ namespace Microsoft.WindowsAzure.Storage.Table
         /// <returns><c>true</c> if the table already existed and was deleted; otherwise, <c>false</c>.</returns>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         [DoesServiceRequest]
-        public virtual Task<bool> DeleteIfExistsAsync(TableRequestOptions requestOptions, OperationContext operationContext, CancellationToken cancellationToken)
+        public virtual async Task<bool> DeleteIfExistsAsync(TableRequestOptions requestOptions, OperationContext operationContext, CancellationToken cancellationToken)
         {
             requestOptions = TableRequestOptions.ApplyDefaults(requestOptions, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () =>
+            try
             {
-                try
+                if (!await this.ExistsAsync(true, requestOptions, operationContext, cancellationToken).ConfigureAwait(false))
                 {
-                    if (!await this.ExistsAsync(true, requestOptions, operationContext, cancellationToken))
+                    return false;
+                }
+            }
+            catch (StorageException e)
+            {
+                if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Forbidden)
+                {
+                    throw;
+                }
+            }
+
+            try
+            {
+                await this.DeleteAsync(requestOptions, operationContext, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception)
+            {
+                if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
+                    if ((extendedInfo == null) ||
+                        (extendedInfo.ErrorCode == StorageErrorCodeStrings.ResourceNotFound))
                     {
                         return false;
-                    }
-                }
-                catch (StorageException e)
-                {
-                    if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Forbidden)
-                    {
-                        throw;
-                    }
-                }
-
-                try
-                {
-                    await this.DeleteAsync(requestOptions, operationContext, cancellationToken);
-                    return true;
-                }
-                catch (Exception)
-                {
-                    if (operationContext.LastResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
-                    {
-                        StorageExtendedErrorInformation extendedInfo = operationContext.LastResult.ExtendedErrorInformation;
-                        if ((extendedInfo == null) ||
-                            (extendedInfo.ErrorCode == StorageErrorCodeStrings.ResourceNotFound))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            throw;
-                        }
                     }
                     else
                     {
                         throw;
                     }
                 }
-            }, cancellationToken);
+                else
+                {
+                    throw;
+                }
+            }
         }
         #endregion
 
@@ -467,7 +461,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns><c>true</c> if the table exists.</returns>
         [DoesServiceRequest]
-        private Task<bool> ExistsAsync(bool primaryOnly, TableRequestOptions requestOptions, OperationContext operationContext, CancellationToken cancellationToken)
+        private async Task<bool> ExistsAsync(bool primaryOnly, TableRequestOptions requestOptions, OperationContext operationContext, CancellationToken cancellationToken)
         {
             requestOptions = TableRequestOptions.ApplyDefaults(requestOptions, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
@@ -478,13 +472,10 @@ namespace Microsoft.WindowsAzure.Storage.Table
             operation.IsTableEntity = true;
             operation.IsPrimaryOnlyRetrieve = primaryOnly;
 
-            return Task.Run(async () =>
-            {
-                TableResult res = await this.ServiceClient.ExecuteAsync(TableConstants.TableServiceTablesName, operation, requestOptions, operationContext, cancellationToken);
+            TableResult res = await this.ServiceClient.ExecuteAsync(TableConstants.TableServiceTablesName, operation, requestOptions, operationContext, cancellationToken).ConfigureAwait(false);
 
-                // Only other option is not found, other status codes will throw prior to this.            
-                return res.HttpStatusCode == (int)HttpStatusCode.OK;
-            }, cancellationToken);
+            // Only other option is not found, other status codes will throw prior to this.            
+            return res.HttpStatusCode == (int)HttpStatusCode.OK;
         }
         #endregion
 
@@ -527,11 +518,11 @@ namespace Microsoft.WindowsAzure.Storage.Table
             TableRequestOptions modifiedOptions = TableRequestOptions.ApplyDefaults(requestOptions, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () => await Executor.ExecuteAsyncNullReturn(
-                                                            this.SetPermissionsImpl(permissions, modifiedOptions),
-                                                            modifiedOptions.RetryPolicy,
-                                                            operationContext,
-                                                            cancellationToken), cancellationToken);
+            return Executor.ExecuteAsyncNullReturn(
+                this.SetPermissionsImpl(permissions, modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         /// <summary>
@@ -596,11 +587,11 @@ namespace Microsoft.WindowsAzure.Storage.Table
             TableRequestOptions modifiedOptions = TableRequestOptions.ApplyDefaults(requestOptions, this.ServiceClient);
             operationContext = operationContext ?? new OperationContext();
 
-            return Task.Run(async () => await Executor.ExecuteAsync(
-                                                        this.GetPermissionsImpl(modifiedOptions),
-                                                        modifiedOptions.RetryPolicy,
-                                                        operationContext,
-                                                        cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                this.GetPermissionsImpl(modifiedOptions),
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         /// <summary>
@@ -620,12 +611,9 @@ namespace Microsoft.WindowsAzure.Storage.Table
             getCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp, null /* retVal */, cmd, ex);
             getCmd.PostProcessResponse = (cmd, resp, ctx) =>
             {
-                return Task<TablePermissions>.Factory.StartNew(() =>
-                {
-                    TablePermissions TableAcl = new TablePermissions();
-                    HttpResponseParsers.ReadSharedAccessIdentifiers(TableAcl.SharedAccessPolicies, new TableAccessPolicyResponse(cmd.ResponseStream));
-                    return TableAcl;
-                });
+                TablePermissions TableAcl = new TablePermissions();
+                HttpResponseParsers.ReadSharedAccessIdentifiers(TableAcl.SharedAccessPolicies, new TableAccessPolicyResponse(cmd.ResponseStream));
+                return Task.FromResult(TableAcl);
             };
 
             return getCmd;

--- a/Lib/WindowsRuntime/Table/Protocol/HttpResponseAdapterMessage.cs
+++ b/Lib/WindowsRuntime/Table/Protocol/HttpResponseAdapterMessage.cs
@@ -28,7 +28,7 @@ namespace Microsoft.WindowsAzure.Storage.Table.Protocol
     internal class HttpResponseAdapterMessage : IODataResponseMessageAsync
     {
         private HttpResponseMessage resp = null;
-        private Stream str = null;
+        private Task<Stream> strAsCachedTask = null;
         private string responseContentType = null;
 
         public HttpResponseAdapterMessage(HttpResponseMessage resp, Stream str)
@@ -39,13 +39,13 @@ namespace Microsoft.WindowsAzure.Storage.Table.Protocol
         public HttpResponseAdapterMessage(HttpResponseMessage resp, Stream str, string responseContentType)
         {
             this.resp = resp;
-            this.str = str;
+            this.strAsCachedTask = Task.FromResult(str);
             this.responseContentType = responseContentType;
         }
 
         public Task<Stream> GetStreamAsync()
         {
-            return Task.Factory.StartNew(() => this.str);
+            return strAsCachedTask;
         }
 
         public string GetHeader(string headerName)
@@ -75,7 +75,7 @@ namespace Microsoft.WindowsAzure.Storage.Table.Protocol
 
         public Stream GetStream()
         {
-            return this.str;
+            return this.strAsCachedTask.Result; // safe since completed task and avoids additional field for stream
         }
 
         public IEnumerable<KeyValuePair<string, string>> Headers

--- a/Lib/WindowsRuntime/Table/TableBatchOperation.cs
+++ b/Lib/WindowsRuntime/Table/TableBatchOperation.cs
@@ -56,11 +56,11 @@ namespace Microsoft.WindowsAzure.Storage.Table
 
             RESTCommand<IList<TableResult>> cmdToExecute = BatchImpl(this, client, tableName, modifiedOptions);
 
-            return Task.Run(async () => await Executor.ExecuteAsync(
-                                                            cmdToExecute,
-                                                            modifiedOptions.RetryPolicy,
-                                                            operationContext,
-                                                            cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                cmdToExecute,
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private static RESTCommand<IList<TableResult>> BatchImpl(TableBatchOperation batch, CloudTableClient client, string tableName, TableRequestOptions requestOptions)

--- a/Lib/WindowsRuntime/Table/TableQuery.cs
+++ b/Lib/WindowsRuntime/Table/TableQuery.cs
@@ -99,7 +99,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
             queryCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp.StatusCode, null /* retVal */, cmd, ex);
             queryCmd.PostProcessResponse = async (cmd, resp, ctx) =>
             {
-                ResultSegment<DynamicTableEntity> resSeg = await TableOperationHttpResponseParsers.TableQueryPostProcessGeneric<DynamicTableEntity>(cmd.ResponseStream, resolver.Invoke, resp, requestOptions, ctx, client.AccountName);
+                ResultSegment<DynamicTableEntity> resSeg = await TableOperationHttpResponseParsers.TableQueryPostProcessGeneric<DynamicTableEntity>(cmd.ResponseStream, resolver.Invoke, resp, requestOptions, ctx, client.AccountName).ConfigureAwait(false);
                 if (resSeg.ContinuationToken != null)
                 {
                     resSeg.ContinuationToken.TargetLocation = cmd.CurrentResult.TargetLocation;
@@ -147,7 +147,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
             queryCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp.StatusCode, null /* retVal */, cmd, ex);
             queryCmd.PostProcessResponse = async (cmd, resp, ctx) =>
             {
-                ResultSegment<RESULT_TYPE> resSeg = await TableOperationHttpResponseParsers.TableQueryPostProcessGeneric<RESULT_TYPE>(cmd.ResponseStream, resolver.Invoke, resp, requestOptions, ctx, client.AccountName);
+                ResultSegment<RESULT_TYPE> resSeg = await TableOperationHttpResponseParsers.TableQueryPostProcessGeneric<RESULT_TYPE>(cmd.ResponseStream, resolver.Invoke, resp, requestOptions, ctx, client.AccountName).ConfigureAwait(false);
                 if (resSeg.ContinuationToken != null)
                 {
                     resSeg.ContinuationToken.TargetLocation = cmd.CurrentResult.TargetLocation;

--- a/Lib/WindowsRuntime/Table/TableQuery.cs
+++ b/Lib/WindowsRuntime/Table/TableQuery.cs
@@ -71,11 +71,11 @@ namespace Microsoft.WindowsAzure.Storage.Table
 
             RESTCommand<TableQuerySegment> cmdToExecute = QueryImpl(this, continuationToken, client, tableName, EntityUtilities.ResolveEntityByType<DynamicTableEntity>, modifiedOptions);
 
-            return Task.Run(async () => await Executor.ExecuteAsync(
-                                                            cmdToExecute,
-                                                            modifiedOptions.RetryPolicy,
-                                                            operationContext,
-                                                            cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                cmdToExecute,
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private static RESTCommand<TableQuerySegment> QueryImpl(TableQuery query, TableContinuationToken token, CloudTableClient client, string tableName, EntityResolver<DynamicTableEntity> resolver, TableRequestOptions requestOptions)
@@ -119,11 +119,11 @@ namespace Microsoft.WindowsAzure.Storage.Table
 
             RESTCommand<TableQuerySegment<TResult>> cmdToExecute = this.QueryImpl<TResult>(continuationToken, client, tableName, resolver, modifiedOptions);
 
-            return Task.Run(async () => await Executor.ExecuteAsync(
-                                                            cmdToExecute,
-                                                            modifiedOptions.RetryPolicy,
-                                                            operationContext,
-                                                            cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                cmdToExecute,
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private RESTCommand<TableQuerySegment<RESULT_TYPE>> QueryImpl<RESULT_TYPE>(TableContinuationToken token, CloudTableClient client, string tableName, EntityResolver<RESULT_TYPE> resolver, TableRequestOptions requestOptions)

--- a/Lib/WindowsRuntime/Table/TableQueryGeneric.cs
+++ b/Lib/WindowsRuntime/Table/TableQueryGeneric.cs
@@ -147,7 +147,7 @@ namespace Microsoft.WindowsAzure.Storage.Table
             queryCmd.PreProcessResponse = (cmd, resp, ex, ctx) => HttpResponseParsers.ProcessExpectedStatusCodeNoException(HttpStatusCode.OK, resp.StatusCode, null /* retVal */, cmd, ex);
             queryCmd.PostProcessResponse = async (cmd, resp, ctx) =>
             {
-                ResultSegment<RESULT_TYPE> resSeg = await TableOperationHttpResponseParsers.TableQueryPostProcessGeneric<RESULT_TYPE>(cmd.ResponseStream, resolver.Invoke, resp, requestOptions, ctx, client.AccountName);
+                ResultSegment<RESULT_TYPE> resSeg = await TableOperationHttpResponseParsers.TableQueryPostProcessGeneric<RESULT_TYPE>(cmd.ResponseStream, resolver.Invoke, resp, requestOptions, ctx, client.AccountName).ConfigureAwait(false);
                 if (resSeg.ContinuationToken != null)
                 {
                     resSeg.ContinuationToken.TargetLocation = cmd.CurrentResult.TargetLocation;

--- a/Lib/WindowsRuntime/Table/TableQueryGeneric.cs
+++ b/Lib/WindowsRuntime/Table/TableQueryGeneric.cs
@@ -76,11 +76,11 @@ namespace Microsoft.WindowsAzure.Storage.Table
 
             RESTCommand<TableQuerySegment<TElement>> cmdToExecute = QueryImpl(this, token, client, tableName, EntityUtilities.ResolveEntityByType<TElement>, modifiedOptions);
 
-            return Task.Run(async () => await Executor.ExecuteAsync(
-                                                        cmdToExecute,
-                                                        modifiedOptions.RetryPolicy,
-                                                        operationContext,
-                                                        cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                cmdToExecute,
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         internal IEnumerable<TResult> Execute<TResult>(CloudTableClient client, string tableName, EntityResolver<TResult> resolver, TableRequestOptions requestOptions, OperationContext operationContext)
@@ -119,11 +119,11 @@ namespace Microsoft.WindowsAzure.Storage.Table
 
             RESTCommand<TableQuerySegment<TResult>> cmdToExecute = QueryImpl(this, token, client, tableName, resolver, modifiedOptions);
 
-            return Task.Run(() => Executor.ExecuteAsync(
-                                            cmdToExecute,
-                                            modifiedOptions.RetryPolicy,
-                                            operationContext,
-                                            cancellationToken), cancellationToken);
+            return Executor.ExecuteAsync(
+                cmdToExecute,
+                modifiedOptions.RetryPolicy,
+                operationContext,
+                cancellationToken);
         }
 
         private static RESTCommand<TableQuerySegment<RESULT_TYPE>> QueryImpl<T, RESULT_TYPE>(TableQuery<T> query, TableContinuationToken token, CloudTableClient client, string tableName, EntityResolver<RESULT_TYPE> resolver, TableRequestOptions requestOptions) where T : ITableEntity, new()


### PR DESCRIPTION
This is a WIP PR

When doing performance investigations with ASQ on .NET Core I stumbled upon the [improper usage](https://channel9.msdn.com/Series/Three-Essential-Tips-for-Async/Async-Library-Methods-Shouldn-t-Lie) of `Task.Run` and `Task.Factory.StartNew` around pure async code.

`Task.Run` and `Task.Factory.StartNew` is for [compute-bound code and not for IO-bound](https://channel9.msdn.com/Series/Three-Essential-Tips-for-Async/Tip-2-Distinguish-CPU-Bound-work-from-IO-bound-work).

Without explicitly forcing those operations unnecessarily to the thread pool the code will not suffer thread pool ramp up and drastically improve performance under highly concurrent asynchronous runs