### PR TITLE
Add Repository information to NuSpec 

### DIFF
--- a/Lib/AspNet/Microsoft.WindowsAzure.Storage/WindowsAzure.StorageK.nuspec
+++ b/Lib/AspNet/Microsoft.WindowsAzure.Storage/WindowsAzure.StorageK.nuspec
@@ -10,7 +10,7 @@
     <licenseUrl>https://github.com/Azure/azure-storage-net/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/Azure/azure-storage-net</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
-		<repository type="git" url="https://github.com/Azure/azure-storage-net.git" />
+    <repository type="git" url="https://github.com/Azure/azure-storage-net.git" />
     <description>This client library enables working with the Microsoft Azure storage services which include the blob and file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.
       For this release see notes - https://github.com/Azure/azure-storage-net/blob/master/README.md and https://github.com/Azure/azure-storage-net/blob/master/changelog.txt
       Microsoft Azure Storage team's blog - http://blogs.msdn.com/b/windowsazurestorage/</description>

--- a/Lib/AspNet/Microsoft.WindowsAzure.Storage/WindowsAzure.StorageK.nuspec
+++ b/Lib/AspNet/Microsoft.WindowsAzure.Storage/WindowsAzure.StorageK.nuspec
@@ -7,9 +7,10 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=331471</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=235168</projectUrl>
+    <licenseUrl>https://github.com/Azure/azure-storage-net/blob/master/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/Azure/azure-storage-net</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
+		<repository type="git" url="https://github.com/Azure/azure-storage-net.git" />
     <description>This client library enables working with the Microsoft Azure storage services which include the blob and file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.
       For this release see notes - https://github.com/Azure/azure-storage-net/blob/master/README.md and https://github.com/Azure/azure-storage-net/blob/master/changelog.txt
       Microsoft Azure Storage team's blog - http://blogs.msdn.com/b/windowsazurestorage/</description>

--- a/Lib/WindowsDesktop/WindowsAzure.Storage.nuspec
+++ b/Lib/WindowsDesktop/WindowsAzure.Storage.nuspec
@@ -10,7 +10,7 @@
     <licenseUrl>https://github.com/Azure/azure-storage-net/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/Azure/azure-storage-net</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
-		<repository type="git" url="https://github.com/Azure/azure-storage-net.git" />
+    <repository type="git" url="https://github.com/Azure/azure-storage-net.git" />
     <description>This client library enables working with the Microsoft Azure storage services which include the blob and file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.
       For this release see notes - https://github.com/Azure/azure-storage-net/blob/master/README.md and https://github.com/Azure/azure-storage-net/blob/master/changelog.txt
       Microsoft Azure Storage team's blog - http://blogs.msdn.com/b/windowsazurestorage/</description>

--- a/Lib/WindowsDesktop/WindowsAzure.Storage.nuspec
+++ b/Lib/WindowsDesktop/WindowsAzure.Storage.nuspec
@@ -7,9 +7,10 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=331471</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=235168</projectUrl>
+    <licenseUrl>https://github.com/Azure/azure-storage-net/blob/master/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/Azure/azure-storage-net</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</iconUrl>
+		<repository type="git" url="https://github.com/Azure/azure-storage-net.git" />
     <description>This client library enables working with the Microsoft Azure storage services which include the blob and file service for storing binary and text data, the table service for storing structured non-relational data, and the queue service for storing messages that may be accessed by a client.
       For this release see notes - https://github.com/Azure/azure-storage-net/blob/master/README.md and https://github.com/Azure/azure-storage-net/blob/master/changelog.txt
       Microsoft Azure Storage team's blog - http://blogs.msdn.com/b/windowsazurestorage/</description>


### PR DESCRIPTION
Nuget provides elements to specify where the source code repository is for a nuget package, by specifying a [repository element](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd#L67).

It would be great if we had this information straight into the .nuspec, which would allow tooling such as [Renovate](https://renovatebot.com/) to fetch detailed information about releases (what specifically has been fixed [sample](https://github.com/tomkerkhove/promitor/pull/101)).

Because of this I propose to change the NuSpec as following:
- Adds the repository location
- Update the `licenseUrl` to link to license on this repo
- Update the `projectUrl` to make it easier to find this Git repo
 
See [this blog post](https://blog.tomkerkhove.be/2018/07/08/using-renovate-to-maintain-nuget-docker-dependencies/) for more context.