### PR TITLE
Locale-specific parsing failure

### DIFF
--- a/Lib/ClassLibraryCommon/Blob/Protocol/BlobHttpResponseParsers.cs
+++ b/Lib/ClassLibraryCommon/Blob/Protocol/BlobHttpResponseParsers.cs
@@ -60,7 +60,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob.Protocol
             properties.ContentLanguage = response.Headers[Constants.HeaderConstants.ContentLanguageHeader];
 #else
             string created = response.Headers[Constants.HeaderConstants.CreationTimeHeader];
-            properties.Created = string.IsNullOrEmpty(created) ? (DateTimeOffset?)null : DateTimeOffset.Parse(created).ToUniversalTime();
+            properties.Created = string.IsNullOrEmpty(created) ? (DateTimeOffset?)null : DateTimeOffset.Parse(created, CultureInfo.InvariantCulture).ToUniversalTime();
             
             properties.LastModified = response.LastModified.ToUniversalTime();
             properties.ContentLanguage = response.Headers[HttpResponseHeader.ContentLanguage];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Changes in xx.xx.xx:
+- Blob: Fixed a bug introduced with the blob creation time property, where cultures other than en-US would fail to parse blob headers.
+
 Changes in 9.3.0:
 - All: Support for 2018-03-28 REST version. Please see our REST API documentation and blogs for information about the related added features. If you are using the Storage Emulator, please update to Emulator version 5.6.
 - Blob: Added support for put block using a source URI and range.


### PR DESCRIPTION
Fixed a bug where code with a non "en-US" locale would crash while
parsing blob header info.