### PR TITLE
Fix File/BlobReadStream ignoring passed in CancellationToken

### DIFF
--- a/Blob/Changelog.txt
+++ b/Blob/Changelog.txt
@@ -3,6 +3,7 @@ Changes in 9.4.0:
 - Feature parity with the 9.3.2 release of the non-split library.
 - Removed support for PCL and NetStandard 1.0.
 - Moving back to using Microsoft.WindowsAzure.Storage instead of Microsoft.Azure.Storage.  This is a temporary change to ease the transition for existing libraries.  The namespace will change back at a future time.
+- Fixed issue where BlobReadStream.ReadAsync didn't appropriately use the passed in CancellationToken.
 
 Changes in 9.4.0-preview:
 

--- a/File/Changelog.txt
+++ b/File/Changelog.txt
@@ -3,6 +3,7 @@ Changes in 9.4.0:
 - Feature parity with the 9.3.2 release of the non-split library.
 - Removed support for PCL and NetStandard 1.0.
 - Moving back to using Microsoft.WindowsAzure.Storage instead of Microsoft.Azure.Storage.  This is a temporary change to ease the transition for existing libraries.  The namespace will change back at a future time.
+- Fixed issue where FileReadStream.ReadAsync didn't appropriately use the passed in CancellationToken.
 
 Changes in 9.4.0-preview:
 

--- a/Lib/ClassLibraryCommon/Blob/BlobReadStream.cs
+++ b/Lib/ClassLibraryCommon/Blob/BlobReadStream.cs
@@ -131,6 +131,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="offset">The byte offset in buffer at which to begin writing
         /// data read from the stream.</param>
         /// <param name="count">The maximum number of bytes to read.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>Number of bytes read from the stream.</returns>
         private async Task<int> DispatchReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {

--- a/Lib/ClassLibraryCommon/File/FileReadStream.cs
+++ b/Lib/ClassLibraryCommon/File/FileReadStream.cs
@@ -115,7 +115,7 @@ namespace Microsoft.WindowsAzure.Storage.File
                 return Task.FromResult(readCount);
             }
 
-            return this.DispatchReadASync(buffer, offset, count);
+            return this.DispatchReadAsync(buffer, offset, count, cancellationToken);
         }
 
         /// <summary>
@@ -126,8 +126,9 @@ namespace Microsoft.WindowsAzure.Storage.File
         /// <param name="offset">The byte offset in buffer at which to begin writing
         /// data read from the stream.</param>
         /// <param name="count">The maximum number of bytes to read.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>Number of bytes read from the stream.</returns>
-        private async Task<int> DispatchReadASync(byte[] buffer, int offset, int count)
+        private async Task<int> DispatchReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             try
             {
@@ -138,7 +139,8 @@ namespace Microsoft.WindowsAzure.Storage.File
                     this.GetReadSize(),
                     null /* accessCondition */,
                     this.options,
-                    this.operationContext).ConfigureAwait(false);
+                    this.operationContext,
+                    cancellationToken).ConfigureAwait(false);
 
                 if (!this.file.Properties.ETag.Equals(this.accessCondition.IfMatchETag, StringComparison.Ordinal))
                 {

--- a/Lib/WindowsRuntime/Blob/BlobReadStream.cs
+++ b/Lib/WindowsRuntime/Blob/BlobReadStream.cs
@@ -117,7 +117,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                 return Task.FromResult(readCount);
             }
 
-            return this.DispatchReadAsync(buffer, offset, count);
+            return this.DispatchReadAsync(buffer, offset, count, cancellationToken);
         }
 
         /// <summary>
@@ -128,8 +128,9 @@ namespace Microsoft.WindowsAzure.Storage.Blob
         /// <param name="offset">The byte offset in buffer at which to begin writing
         /// data read from the stream.</param>
         /// <param name="count">The maximum number of bytes to read.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>Number of bytes read from the stream.</returns>
-        private async Task<int> DispatchReadAsync(byte[] buffer, int offset, int count)
+        private async Task<int> DispatchReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             try
             {
@@ -140,7 +141,8 @@ namespace Microsoft.WindowsAzure.Storage.Blob
                     this.GetReadSize(),
                     this.accessCondition,
                     this.options,
-                    this.operationContext).ConfigureAwait(false);
+                    this.operationContext,
+                    cancellationToken).ConfigureAwait(false);
 
                 this.internalBuffer.Seek(0, SeekOrigin.Begin);
                 return this.ConsumeBuffer(buffer, offset, count);

--- a/Lib/WindowsRuntime/File/FileReadStream.cs
+++ b/Lib/WindowsRuntime/File/FileReadStream.cs
@@ -118,7 +118,7 @@ namespace Microsoft.WindowsAzure.Storage.File
                 return Task.FromResult(readCount);
             }
 
-            return this.DispatchReadASync(buffer, offset, count);
+            return this.DispatchReadASync(buffer, offset, count, cancellationToken);
         }
 
         /// <summary>
@@ -129,8 +129,9 @@ namespace Microsoft.WindowsAzure.Storage.File
         /// <param name="offset">The byte offset in buffer at which to begin writing
         /// data read from the stream.</param>
         /// <param name="count">The maximum number of bytes to read.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>Number of bytes read from the stream.</returns>
-        private async Task<int> DispatchReadASync(byte[] buffer, int offset, int count)
+        private async Task<int> DispatchReadASync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             try
             {
@@ -141,7 +142,8 @@ namespace Microsoft.WindowsAzure.Storage.File
                     this.GetReadSize(),
                     null /* accessCondition */,
                     this.options,
-                    this.operationContext).ConfigureAwait(false);
+                    this.operationContext,
+                    cancellationToken).ConfigureAwait(false);
 
                 if (!this.file.Properties.ETag.Equals(this.accessCondition.IfMatchETag, StringComparison.Ordinal))
                 {

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ We gladly accept community contributions.
 
 - Issues: Please report bugs using the Issues section of GitHub
 - Forums: Interact with the development teams on StackOverflow or the Microsoft Azure Forums
-- Source Code Contributions: Please see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute code.
+- Source Code Contributions: Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) for instructions on how to contribute code.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 


### PR DESCRIPTION
Hey there!

First contribution, please forgive me if I made any mistakes. Thanks for a great project! :-)

This fixes #765
This looks to be a simple oversight that affected both `BlobReadStream` and `FileReadStream`.

The contribution guidelines seem to be out of date, so I thought I'd just fire off a PR and discuss it. Hope you don't mind!

> Discuss any proposed contribution with the team via a GitHub issue before starting development.

The solution in this case seemed simple enough to not require prior discussion.

Also, the `CONTRIBUTING.md` link was out of date, thought I'd fix that whilst I was here. Hope that's OK!





