### PR TITLE
FixMetadata and Pass Missing CancellationToken

### DIFF
--- a/Blob/Changelog.txt
+++ b/Blob/Changelog.txt
@@ -14,6 +14,7 @@ Changes in 9.4.0-preview:
 - All: Updated Get*BlobReference APIs to inherit the existing ServiceClient instance.
 - All: Removed the un-necessary stream wrapping when progress tracking is not requested.
 - Blob(RT/NetCore): Removed Task.Run from CloudBlob Undelete API.
+- Fixed issue where CloudBlob.StartCopyImpl didn't appropriately use the passed in CancellationToken.
 
 Changes in 9.0.0-preview:
 - All: Support for 2017-07-29 REST version. Please see our REST API documentation and blogs for information about the related added features. If you are using the Storage Emulator, please update to Emulator version 5.3.

--- a/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlob.cs
@@ -3882,23 +3882,23 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             return putCmd;
         }
 
-    /// <summary>
-    /// Implementation of the StartCopy method. Result is a BlobAttributes object derived from the response headers.
-    /// </summary>
-    /// <param name="blobAttributes">The attributes.</param>
-    /// <param name="source">The URI of the source blob.</param>
-    /// <param name="sourceContentMD5">An optional hash value used to ensure transactional integrity for the operation. May be <c>null</c> or an empty string.</param>
-    /// <param name="incrementalCopy">A boolean indicating whether or not this is an incremental copy</param>
-    /// <param name="syncCopy">A boolean to enable synchronous server copy of blobs.</param>
-    /// <param name="premiumPageBlobTier">A <see cref="PremiumPageBlobTier"/> representing the tier to set.</param>
-    /// <param name="sourceAccessCondition">An <see cref="AccessCondition"/> object that represents the access conditions for the source object. If <c>null</c>, no condition is used.</param>
-    /// <param name="destAccessCondition">An <see cref="AccessCondition"/> object that represents the access conditions for the destination blob. If <c>null</c>, no condition is used.</param>
-    /// <param name="options">A <see cref="BlobRequestOptions"/> object that specifies additional options for the request.</param>
-    /// <returns>
-    /// A <see cref="RESTCommand{T}"/> that starts to copy.
-    /// </returns>
-    /// <exception cref="System.ArgumentException">sourceAccessCondition</exception>
-    internal RESTCommand<string> StartCopyImpl(BlobAttributes attributes, Uri source, string sourceContentMD5, bool incrementalCopy, bool syncCopy, PremiumPageBlobTier? premiumPageBlobTier, AccessCondition sourceAccessCondition, AccessCondition destAccessCondition, BlobRequestOptions options)
+        /// <summary>
+        /// Implementation of the StartCopy method. Result is a BlobAttributes object derived from the response headers.
+        /// </summary>
+        /// <param name="attributes">The attributes.</param>
+        /// <param name="source">The URI of the source blob.</param>
+        /// <param name="sourceContentMD5">An optional hash value used to ensure transactional integrity for the operation. May be <c>null</c> or an empty string.</param>
+        /// <param name="incrementalCopy">A boolean indicating whether or not this is an incremental copy</param>
+        /// <param name="syncCopy">A boolean to enable synchronous server copy of blobs.</param>
+        /// <param name="premiumPageBlobTier">A <see cref="PremiumPageBlobTier"/> representing the tier to set.</param>
+        /// <param name="sourceAccessCondition">An <see cref="AccessCondition"/> object that represents the access conditions for the source object. If <c>null</c>, no condition is used.</param>
+        /// <param name="destAccessCondition">An <see cref="AccessCondition"/> object that represents the access conditions for the destination blob. If <c>null</c>, no condition is used.</param>
+        /// <param name="options">A <see cref="BlobRequestOptions"/> object that specifies additional options for the request.</param>
+        /// <returns>
+        /// A <see cref="RESTCommand{T}"/> that starts to copy.
+        /// </returns>
+        /// <exception cref="System.ArgumentException">sourceAccessCondition</exception>
+        internal RESTCommand<string> StartCopyImpl(BlobAttributes attributes, Uri source, string sourceContentMD5, bool incrementalCopy, bool syncCopy, PremiumPageBlobTier? premiumPageBlobTier, AccessCondition sourceAccessCondition, AccessCondition destAccessCondition, BlobRequestOptions options)
     {
         if (sourceAccessCondition != null && !string.IsNullOrEmpty(sourceAccessCondition.LeaseId))
         {

--- a/Lib/ClassLibraryCommon/Blob/CloudBlobClient.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlobClient.cs
@@ -457,7 +457,7 @@ namespace Microsoft.WindowsAzure.Storage.Blob
             CloudBlobClient.ParseUserPrefix(prefix, out containerName, out listingPrefix);
 
             CloudBlobContainer container = this.GetContainerReference(containerName);
-            return container.ListBlobsSegmentedAsync(listingPrefix, useFlatBlobListing, blobListingDetails, maxResults, currentToken, options, operationContext);
+            return container.ListBlobsSegmentedAsync(listingPrefix, useFlatBlobListing, blobListingDetails, maxResults, currentToken, options, operationContext, cancellationToken);
         }
 #endif
 


### PR DESCRIPTION
- Fix  a metadata in CloudBlob.StartCopyImpl
- Pass CancellationToken in `CloudBlobClient.ListBlobsSegmentedAsync`

Thanks.