### PR TITLE
adding constructor for oauth token + account name

### DIFF
--- a/Lib/Common/Auth/StorageCredentials.cs
+++ b/Lib/Common/Auth/StorageCredentials.cs
@@ -221,6 +221,19 @@ namespace Microsoft.Azure.Storage.Auth
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="StorageCredentials"/> class with the specified bearer token and account name.
+        /// </summary>
+        /// <param name="tokenCredential">The authentication token.</param>
+        /// <param name="accountName">A string that represents the name of the storage account.</param>
+        public StorageCredentials(TokenCredential tokenCredential, string accountName)
+        {
+            CommonUtility.AssertNotNullOrEmpty("accountName", accountName);
+
+            this.AccountName = accountName;
+            this.TokenCredential = tokenCredential;
+        }
+
+        /// <summary>
         /// Updates the key value for the credentials.
         /// </summary>
         /// <param name="keyValue">The key value, as a Base64-encoded string, to update.</param>


### PR DESCRIPTION
Due to the prolific use of credentials.AccountName throughout the Azure SDKs, it would be really useful if we could set the account name when using AAD auth (instead of SAS or shared key).