### PR TITLE
Fix CloudFileShare.GetStats() fail with big File Share

### DIFF
--- a/Lib/Common/File/Protocol/ShareStats.cs
+++ b/Lib/Common/File/Protocol/ShareStats.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Storage.File.Protocol
         {
             XElement shareStatsElement = shareStatsDocument.Element(ShareStatsName);
 
-            int usageInBytes = int.Parse(shareStatsElement.Element(ShareUsageBytes).Value, CultureInfo.InvariantCulture);
+            long usageInBytes = long.Parse(shareStatsElement.Element(ShareUsageBytes).Value, CultureInfo.InvariantCulture);
             int usage = (int)Math.Ceiling(usageInBytes / (double)Constants.GB);
 
             return new ShareStats()


### PR DESCRIPTION
Fix CloudFileShare.GetStats() fail with big File Share (e.g. 5+GB)

The related bug is:
https://msazure.visualstudio.com/One/_workitems/edit/5407402 

Customer issues:
https://social.msdn.microsoft.com/Forums/en-US/6af9db57-b45e-4967-ab88-e009a6762ea9/azure-file-share-powershell-getstats-throws-int32-error?forum=windowsazuredata
https://stackoverflow.com/questions/57974990/azure-file-share-usage-throws-int32-error

This PR only contains product code change, I have tested it works on a File share with 15GB.
This PR don't contains any other change, like Unit test or change log.