### PR TITLE
Fix #928 Fix formatting of GetRootContainerReference xmldoc remarks

### DIFF
--- a/Lib/Common/Blob/CloudBlobClient.Common.cs
+++ b/Lib/Common/Blob/CloudBlobClient.Common.cs
@@ -187,8 +187,7 @@ namespace Microsoft.Azure.Storage.Blob
         /// Returns a reference to the root container.
         /// </summary>
         /// <returns>A <see cref="CloudBlobContainer"/> object.</returns>
-        /// <remarks>Note that the root container must be explicitly created, if it does not already exist, before
-        /// you can read from it or write to it.</remarks>
+        /// <remarks>Note that the root container must be explicitly created, if it does not already exist, before you can read from it or write to it.</remarks>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Reviewed")]
         public virtual CloudBlobContainer GetRootContainerReference()
         {


### PR DESCRIPTION
Fix #928 

This change fixes the formatting of the `<remarks>` field of the xmldoc for CloudBlobClient.GetRootContainerReference. It appears fine when reading the source code, but on docs.microsoft.com, the second line appears indented. I think this may be because of the newline in this block.

This newline in this block has been removed. There are other LOC in this file that are around or above the character count per line, if keeping a consistent ruler is an issue.