### PR TITLE
Use cancellationToken argument in GetAccountPropertiesAsync

### DIFF
--- a/Lib/ClassLibraryCommon/Blob/CloudBlobClient.cs
+++ b/Lib/ClassLibraryCommon/Blob/CloudBlobClient.cs
@@ -951,7 +951,7 @@ namespace Microsoft.Azure.Storage.Blob
         [DoesServiceRequest]
         public virtual Task<AccountProperties> GetAccountPropertiesAsync(CancellationToken cancellationToken)
         {
-            return this.GetAccountPropertiesAsync(default(BlobRequestOptions), default(OperationContext), CancellationToken.None);
+            return this.GetAccountPropertiesAsync(default(BlobRequestOptions), default(OperationContext), cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
`GetAccountPropertiesAsync(CancellationToken)` was passing CancellationToken.None instead of the provided CancellationToken.