### PR TITLE
Enforce timeout on network read/writes.

### DIFF
--- a/Lib/ClassLibraryCommon/Core/ByteCountingStream.cs
+++ b/Lib/ClassLibraryCommon/Core/ByteCountingStream.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.Storage.Core
     using Microsoft.Azure.Storage.Core.Util;
     using System;
     using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// This class provides a wrapper that will update the Ingress / Egress bytes of a given request result as the stream is used.
@@ -107,6 +109,11 @@ namespace Microsoft.Azure.Storage.Core
             return read;
         }
 
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return this.wrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
         public override int ReadByte()
         {
             int val = this.wrappedStream.ReadByte();
@@ -179,6 +186,11 @@ namespace Microsoft.Azure.Storage.Core
         {
             this.wrappedStream.Write(buffer, offset, count);
             this.requestObject.EgressBytes += count;
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return this.wrappedStream.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
         public override void WriteByte(byte value)

--- a/Lib/ClassLibraryCommon/Core/ByteCountingStream.cs
+++ b/Lib/ClassLibraryCommon/Core/ByteCountingStream.cs
@@ -109,9 +109,11 @@ namespace Microsoft.Azure.Storage.Core
             return read;
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return this.wrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
+            int read = await this.wrappedStream.ReadAsync(buffer, offset, count, cancellationToken);
+            this.requestObject.IngressBytes += read;
+            return read;
         }
 
         public override int ReadByte()
@@ -188,9 +190,10 @@ namespace Microsoft.Azure.Storage.Core
             this.requestObject.EgressBytes += count;
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return this.wrappedStream.WriteAsync(buffer, offset, count, cancellationToken);
+            await this.wrappedStream.WriteAsync(buffer, offset, count, cancellationToken);
+            this.requestObject.EgressBytes += count;
         }
 
         public override void WriteByte(byte value)

--- a/Lib/ClassLibraryCommon/Core/Executor/Executor.cs
+++ b/Lib/ClassLibraryCommon/Core/Executor/Executor.cs
@@ -141,7 +141,12 @@ namespace Microsoft.Azure.Storage.Core.Executor
 
                         // 8. (Potentially reads stream from server)
                         executionState.CurrentOperation = ExecutorOperation.GetResponseStream;
-                        cmd.ResponseStream = await executionState.Resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                        var responseStream = await executionState.Resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                        if (cmd.NetworkTimeout.HasValue)
+                        {
+                            responseStream = new TimeoutStream(responseStream, cmd.NetworkTimeout.Value);
+                        }
+                        cmd.ResponseStream = responseStream;
 
                         // The stream is now available in ResponseStream. Use the stream to parse out the response or error
                         if (executionState.ExceptionRef != null)

--- a/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
+++ b/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Storage.Core
             var source = StartTimeout(cancellationToken, out bool dispose);
             try
             {
-                await this.wrappedStream.FlushAsync(source.Token).WithCancellation(source.Token);
+                await this.wrappedStream.FlushAsync(source.Token);
             }
             finally
             {
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Storage.Core
             var source = StartTimeout(cancellationToken, out bool dispose);
             try
             {
-                return await this.wrappedStream.ReadAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+                return await this.wrappedStream.ReadAsync(buffer, offset, count, source.Token);
             }
             finally
             {
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.Storage.Core
             var source = StartTimeout(cancellationToken, out bool dispose);
             try
             {
-                await this.wrappedStream.WriteAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+                await this.wrappedStream.WriteAsync(buffer, offset, count, source.Token);
             }
             finally
             {

--- a/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
+++ b/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
@@ -1,0 +1,281 @@
+//-----------------------------------------------------------------------
+// <copyright file="ByteCountingStream.cs" company="Microsoft">
+//    Copyright 2013 Microsoft Corporation
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+namespace Microsoft.Azure.Storage.Core
+{
+    using Microsoft.Azure.Storage.Core.Util;
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Stream that will throw a <see cref="OperationCanceledException"/> if it has to wait longer than a configurable timeout to read or write more data
+    /// </summary>
+    internal class TimeoutStream : Stream
+    {
+        private readonly Stream wrappedStream;
+        private TimeSpan readTimeout;
+        private TimeSpan writeTimeout;
+        private CancellationTokenSource cancellationTokenSource;
+
+        public TimeoutStream(Stream wrappedStream, TimeSpan timeout)
+            : this(wrappedStream, timeout, timeout) { }
+
+        public TimeoutStream(Stream wrappedStream, TimeSpan readTimeout, TimeSpan writeTimeout)
+        {
+            CommonUtility.AssertNotNull("WrappedStream", wrappedStream);
+            CommonUtility.AssertNotNull("ReadTimeout", readTimeout);
+            CommonUtility.AssertNotNull("WriteTimeout", writeTimeout);
+            this.wrappedStream = wrappedStream;
+            this.readTimeout = readTimeout;
+            this.writeTimeout = writeTimeout;
+            this.UpdateReadTimeout();
+            this.UpdateWriteTimeout();
+            this.cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public override long Position
+        {
+            get { return this.wrappedStream.Position; }
+            set { this.wrappedStream.Position = value; }
+        }
+
+        public override long Length
+        {
+            get { return this.wrappedStream.Length; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return this.wrappedStream.CanWrite; }
+        }
+
+        public override bool CanTimeout
+        {
+            get { return this.wrappedStream.CanTimeout; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return this.wrappedStream.CanSeek; }
+        }
+
+        public override bool CanRead
+        {
+            get { return this.wrappedStream.CanRead; }
+        }
+
+        public override int ReadTimeout
+        {
+            get { return (int) this.readTimeout.TotalMilliseconds; }
+            set {
+                this.readTimeout = TimeSpan.FromMilliseconds(value);
+                this.UpdateReadTimeout();
+            }
+        }
+
+        public override int WriteTimeout
+        {
+            get { return (int) this.writeTimeout.TotalMilliseconds; }
+            set
+            {
+                this.writeTimeout = TimeSpan.FromMilliseconds(value);
+                this.UpdateWriteTimeout();
+            }
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return this.wrappedStream.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return this.wrappedStream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void Close()
+        {
+            this.wrappedStream.Close();
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return this.wrappedStream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return this.wrappedStream.EndRead(asyncResult);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            this.wrappedStream.EndWrite(asyncResult);
+        }
+
+        public override void Flush()
+        {
+            this.wrappedStream.Flush();
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            var source = StartTimeout(cancellationToken, out bool dispose);
+            try
+            {
+                await this.wrappedStream.FlushAsync(source.Token).WithCancellation(source.Token);
+            }
+            finally
+            {
+                StopTimeout(source, dispose);
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return wrappedStream.Read(buffer, offset, count);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var source = StartTimeout(cancellationToken, out bool dispose);
+            try
+            {
+                return await this.wrappedStream.ReadAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+            }
+            finally
+            {
+                StopTimeout(source, dispose);
+            }
+        }
+
+        public override int ReadByte()
+        {
+            return this.wrappedStream.ReadByte();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return this.wrappedStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            this.wrappedStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            this.wrappedStream.Write(buffer, offset, count);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var source = StartTimeout(cancellationToken, out bool dispose);
+            try
+            {
+                await this.wrappedStream.WriteAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+            }
+            finally
+            {
+                StopTimeout(source, dispose);
+            }
+        }
+
+        public override void WriteByte(byte value)
+        {
+            this.wrappedStream.WriteByte(value);
+        }
+
+        private CancellationTokenSource StartTimeout(CancellationToken additionalToken, out bool dispose)
+        {
+            if (this.cancellationTokenSource.IsCancellationRequested)
+            {
+                this.cancellationTokenSource = new CancellationTokenSource();
+            }
+
+            CancellationTokenSource source;
+            if (additionalToken.CanBeCanceled)
+            {
+                source = CancellationTokenSource.CreateLinkedTokenSource(additionalToken, this.cancellationTokenSource.Token);
+                dispose = true;
+            }
+            else
+            {
+                source = this.cancellationTokenSource;
+                dispose = false;
+            }
+
+            this.cancellationTokenSource.CancelAfter(this.readTimeout);
+
+            return source;
+        }
+
+        private void StopTimeout(CancellationTokenSource source, bool dispose)
+        {
+            this.cancellationTokenSource.CancelAfter(Timeout.InfiniteTimeSpan);
+            if (dispose)
+            {
+                source.Dispose();
+            }
+        }
+
+        private void UpdateReadTimeout()
+        {
+            if (this.wrappedStream.CanTimeout)
+            {
+                try
+                {
+                    this.wrappedStream.ReadTimeout = (int)this.readTimeout.TotalMilliseconds;
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+
+        private void UpdateWriteTimeout()
+        {
+            if (this.wrappedStream.CanTimeout)
+            {
+                try
+                {
+                    this.wrappedStream.WriteTimeout = (int)this.writeTimeout.TotalMilliseconds;
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                this.cancellationTokenSource.Dispose();
+                this.wrappedStream.Dispose();
+            }
+        }
+    }
+}

--- a/Lib/Common/Blob/BlobRequestOptions.cs
+++ b/Lib/Common/Blob/BlobRequestOptions.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Azure.Storage.Blob
             LocationMode = RetryPolicies.LocationMode.PrimaryOnly,
             ServerTimeout = null,
             MaximumExecutionTime = null,
+            NetworkTimeout = Constants.DefaultNetworkTimeout,
             ParallelOperationThreadCount = 1,
             SingleBlobUploadThresholdInBytes = Constants.MaxSingleUploadBlobSize / 2,
 
@@ -114,6 +115,7 @@ namespace Microsoft.Azure.Storage.Blob
                 this.LocationMode = other.LocationMode;
                 this.ServerTimeout = other.ServerTimeout;
                 this.MaximumExecutionTime = other.MaximumExecutionTime;
+                this.NetworkTimeout = other.NetworkTimeout;
                 this.OperationExpiryTime = other.OperationExpiryTime;
                 this.ChecksumOptions.CopyFrom(other.ChecksumOptions);
                 this.ParallelOperationThreadCount = other.ParallelOperationThreadCount;
@@ -161,6 +163,11 @@ namespace Microsoft.Azure.Storage.Blob
                 modifiedOptions.MaximumExecutionTime 
                 ?? serviceClient.DefaultRequestOptions.MaximumExecutionTime 
                 ?? BaseDefaultRequestOptions.MaximumExecutionTime;
+
+            modifiedOptions.NetworkTimeout =
+                modifiedOptions.NetworkTimeout
+                ?? serviceClient.DefaultRequestOptions.NetworkTimeout
+                ?? BaseDefaultRequestOptions.NetworkTimeout;
 
             modifiedOptions.ParallelOperationThreadCount = 
                 modifiedOptions.ParallelOperationThreadCount 
@@ -242,6 +249,8 @@ namespace Microsoft.Azure.Storage.Blob
             {
                 cmd.OperationExpiryTime = DateTime.Now + this.MaximumExecutionTime.Value;
             }
+
+            cmd.NetworkTimeout = this.NetworkTimeout;
         }
 
 #if !(WINDOWS_RT || NETCORE)
@@ -412,6 +421,11 @@ namespace Microsoft.Azure.Storage.Blob
                 this.maximumExecutionTime = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets the timeout applied to an individual network operations.
+        /// </summary>
+        public TimeSpan? NetworkTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the number of blocks that may be simultaneously uploaded.

--- a/Lib/Common/Core/Executor/StorageCommandBase.cs
+++ b/Lib/Common/Core/Executor/StorageCommandBase.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Azure.Storage.Core.Executor
         // Max client timeout, enforced over entire operation on client side
         internal DateTime? OperationExpiryTime = null;
 
+        // Timeout applied to an individual network operations.
+        internal TimeSpan? NetworkTimeout = null;
+
         // State- different than async state, this is used for ops to communicate state between invocations, i.e. bytes downloaded etc
         internal object OperationState = null;
 

--- a/Lib/Common/File/FileRequestOptions.cs
+++ b/Lib/Common/File/FileRequestOptions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.Storage.File
 
             ServerTimeout = null,
             MaximumExecutionTime = null,
+            NetworkTimeout = Constants.DefaultNetworkTimeout,
             ParallelOperationThreadCount = 1,
 
             ChecksumOptions = new ChecksumOptions
@@ -101,6 +102,7 @@ namespace Microsoft.Azure.Storage.File
                 this.LocationMode = other.LocationMode;
                 this.ServerTimeout = other.ServerTimeout;
                 this.MaximumExecutionTime = other.MaximumExecutionTime;
+                this.NetworkTimeout = other.NetworkTimeout;
                 this.OperationExpiryTime = other.OperationExpiryTime;
                 this.ChecksumOptions.CopyFrom(other.ChecksumOptions);
                 this.ParallelOperationThreadCount = other.ParallelOperationThreadCount;
@@ -137,6 +139,12 @@ namespace Microsoft.Azure.Storage.File
                 modifiedOptions.MaximumExecutionTime 
                 ?? serviceClient.DefaultRequestOptions.MaximumExecutionTime 
                 ?? BaseDefaultRequestOptions.MaximumExecutionTime;
+
+
+            modifiedOptions.NetworkTimeout =
+                modifiedOptions.NetworkTimeout
+                ?? serviceClient.DefaultRequestOptions.NetworkTimeout
+                ?? BaseDefaultRequestOptions.NetworkTimeout;
 
             modifiedOptions.ParallelOperationThreadCount = 
                 modifiedOptions.ParallelOperationThreadCount 
@@ -211,6 +219,8 @@ namespace Microsoft.Azure.Storage.File
             {
                 cmd.OperationExpiryTime = DateTime.Now + this.MaximumExecutionTime.Value;
             }
+
+            cmd.NetworkTimeout = this.NetworkTimeout;
         }
 
         /// <summary>
@@ -292,7 +302,12 @@ namespace Microsoft.Azure.Storage.File
 
                 this.maximumExecutionTime = value;
             }
-        }  
+        }
+
+        /// <summary>
+        /// Gets or sets the timeout applied to an individual network operations.
+        /// </summary>
+        public TimeSpan? NetworkTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the number of ranges that may be simultaneously uploaded when uploading a file.

--- a/Lib/Common/IRequestOptions.cs
+++ b/Lib/Common/IRequestOptions.cs
@@ -50,6 +50,12 @@ namespace Microsoft.Azure.Storage
         /// <value>A <see cref="TimeSpan"/> containing the maximum execution time across all potential retries.</value>
         TimeSpan? MaximumExecutionTime { get; set; }
 
+        /// <summary>
+        /// Gets or sets the timeout applied to an individual network operations.
+        /// </summary>
+        /// <value>A <see cref="TimeSpan"/> containing the timeout applied to an individual network operations.</value>
+        TimeSpan? NetworkTimeout { get; set; }
+
 #if !(WINDOWS_RT || NETCORE)
         /// <summary>
         /// Gets or sets a value to indicate whether data written and read by the client library should be encrypted.

--- a/Lib/Common/Queue/QueueRequestOptions.cs
+++ b/Lib/Common/Queue/QueueRequestOptions.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Azure.Storage.Queue
 #endif
             LocationMode = RetryPolicies.LocationMode.PrimaryOnly,
             ServerTimeout = null,
-            MaximumExecutionTime = null
+            MaximumExecutionTime = null,
+            NetworkTimeout = Constants.DefaultNetworkTimeout,
         };
 
         /// <summary>
@@ -73,6 +74,7 @@ namespace Microsoft.Azure.Storage.Queue
                 this.ServerTimeout = other.ServerTimeout;
                 this.LocationMode = other.LocationMode;
                 this.MaximumExecutionTime = other.MaximumExecutionTime;
+                this.NetworkTimeout = other.NetworkTimeout;
                 this.OperationExpiryTime = other.OperationExpiryTime;
             }
         }
@@ -141,6 +143,8 @@ namespace Microsoft.Azure.Storage.Queue
             {
                 cmd.OperationExpiryTime = DateTime.Now + this.MaximumExecutionTime.Value;
             }
+
+            cmd.NetworkTimeout = this.NetworkTimeout;
         }
 
 #if !(WINDOWS_RT || NETCORE)
@@ -210,6 +214,11 @@ namespace Microsoft.Azure.Storage.Queue
 
                 this.maximumExecutionTime = value;
             }
-        }  
+        }
+
+        /// <summary>
+        /// Gets or sets the timeout applied to an individual network operations.
+        /// </summary>
+        public TimeSpan? NetworkTimeout { get; set; }
     }
 }

--- a/Lib/Common/Shared/Protocol/Constants.cs
+++ b/Lib/Common/Shared/Protocol/Constants.cs
@@ -133,6 +133,11 @@ namespace Microsoft.Azure.Storage.Shared.Protocol
         public static readonly TimeSpan MaximumAllowedTimeout = TimeSpan.FromSeconds(int.MaxValue);
 
         /// <summary>
+        /// Default timeout applied to an individual network operations.
+        /// </summary>
+        public static readonly TimeSpan DefaultNetworkTimeout = TimeSpan.FromSeconds(100);
+
+        /// <summary>
         /// Maximum allowed value for Delete Retention Days.
         /// </summary>
         internal static readonly int MaximumAllowedRetentionDays = 365;

--- a/Lib/WindowsRuntime/Core/Executor/Executor.cs
+++ b/Lib/WindowsRuntime/Core/Executor/Executor.cs
@@ -180,7 +180,12 @@ namespace Microsoft.Azure.Storage.Core.Executor
 
                         // 8. (Potentially reads stream from server)
                         executionState.CurrentOperation = ExecutorOperation.GetResponseStream;
-                        cmd.ResponseStream = await executionState.Resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                        var responseStream = await executionState.Resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                        if (cmd.NetworkTimeout.HasValue)
+                        {
+                            responseStream = new TimeoutStream(responseStream, cmd.NetworkTimeout.Value);
+                        }
+                        cmd.ResponseStream = responseStream;
 
                         // The stream is now available in ResponseStream. Use the stream to parse out the response or error
                         if (executionState.ExceptionRef != null)

--- a/Lib/WindowsRuntime/Core/TimeoutStream.cs
+++ b/Lib/WindowsRuntime/Core/TimeoutStream.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Storage.Core
             var source = StartTimeout(cancellationToken, out bool dispose);
             try
             {
-                await this.wrappedStream.FlushAsync(source.Token).WithCancellation(source.Token);
+                await this.wrappedStream.FlushAsync(source.Token);
             }
             finally
             {
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Storage.Core
             var source = StartTimeout(cancellationToken, out bool dispose);
             try
             {
-                return await this.wrappedStream.ReadAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+                return await this.wrappedStream.ReadAsync(buffer, offset, count, source.Token);
             }
             finally
             {
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Storage.Core
             var source = StartTimeout(cancellationToken, out bool dispose);
             try
             {
-                await this.wrappedStream.WriteAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+                await this.wrappedStream.WriteAsync(buffer, offset, count, source.Token);
             }
             finally
             {

--- a/Lib/WindowsRuntime/Core/TimeoutStream.cs
+++ b/Lib/WindowsRuntime/Core/TimeoutStream.cs
@@ -1,0 +1,256 @@
+//-----------------------------------------------------------------------
+// <copyright file="ByteCountingStream.cs" company="Microsoft">
+//    Copyright 2013 Microsoft Corporation
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+namespace Microsoft.Azure.Storage.Core
+{
+    using Microsoft.Azure.Storage.Core.Util;
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Stream that will throw a <see cref="OperationCanceledException"/> if it has to wait longer than a configurable timeout to read or write more data
+    /// </summary>
+    internal class TimeoutStream : Stream
+    {
+        private readonly Stream wrappedStream;
+        private TimeSpan readTimeout;
+        private TimeSpan writeTimeout;
+        private CancellationTokenSource cancellationTokenSource;
+
+        public TimeoutStream(Stream wrappedStream, TimeSpan timeout)
+            : this(wrappedStream, timeout, timeout) { }
+
+        public TimeoutStream(Stream wrappedStream, TimeSpan readTimeout, TimeSpan writeTimeout)
+        {
+            CommonUtility.AssertNotNull("WrappedStream", wrappedStream);
+            CommonUtility.AssertNotNull("ReadTimeout", readTimeout);
+            CommonUtility.AssertNotNull("WriteTimeout", writeTimeout);
+            this.wrappedStream = wrappedStream;
+            this.readTimeout = readTimeout;
+            this.writeTimeout = writeTimeout;
+            this.UpdateReadTimeout();
+            this.UpdateWriteTimeout();
+            this.cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public override long Position
+        {
+            get { return this.wrappedStream.Position; }
+            set { this.wrappedStream.Position = value; }
+        }
+
+        public override long Length
+        {
+            get { return this.wrappedStream.Length; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return this.wrappedStream.CanWrite; }
+        }
+
+        public override bool CanTimeout
+        {
+            get { return this.wrappedStream.CanTimeout; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return this.wrappedStream.CanSeek; }
+        }
+
+        public override bool CanRead
+        {
+            get { return this.wrappedStream.CanRead; }
+        }
+
+        public override int ReadTimeout
+        {
+            get { return (int) this.readTimeout.TotalMilliseconds; }
+            set {
+                this.readTimeout = TimeSpan.FromMilliseconds(value);
+                this.UpdateReadTimeout();
+            }
+        }
+
+        public override int WriteTimeout
+        {
+            get { return (int) this.writeTimeout.TotalMilliseconds; }
+            set
+            {
+                this.writeTimeout = TimeSpan.FromMilliseconds(value);
+                this.UpdateWriteTimeout();
+            }
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return this.wrappedStream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        public override void Flush()
+        {
+            this.wrappedStream.Flush();
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            var source = StartTimeout(cancellationToken, out bool dispose);
+            try
+            {
+                await this.wrappedStream.FlushAsync(source.Token).WithCancellation(source.Token);
+            }
+            finally
+            {
+                StopTimeout(source, dispose);
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return wrappedStream.Read(buffer, offset, count);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var source = StartTimeout(cancellationToken, out bool dispose);
+            try
+            {
+                return await this.wrappedStream.ReadAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+            }
+            finally
+            {
+                StopTimeout(source, dispose);
+            }
+        }
+
+        public override int ReadByte()
+        {
+            return this.wrappedStream.ReadByte();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return this.wrappedStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            this.wrappedStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            this.wrappedStream.Write(buffer, offset, count);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var source = StartTimeout(cancellationToken, out bool dispose);
+            try
+            {
+                await this.wrappedStream.WriteAsync(buffer, offset, count, source.Token).WithCancellation(source.Token);
+            }
+            finally
+            {
+                StopTimeout(source, dispose);
+            }
+        }
+
+        public override void WriteByte(byte value)
+        {
+            this.wrappedStream.WriteByte(value);
+        }
+
+        private CancellationTokenSource StartTimeout(CancellationToken additionalToken, out bool dispose)
+        {
+            if (this.cancellationTokenSource.IsCancellationRequested)
+            {
+                this.cancellationTokenSource = new CancellationTokenSource();
+            }
+
+            CancellationTokenSource source;
+            if (additionalToken.CanBeCanceled)
+            {
+                source = CancellationTokenSource.CreateLinkedTokenSource(additionalToken, this.cancellationTokenSource.Token);
+                dispose = true;
+            }
+            else
+            {
+                source = this.cancellationTokenSource;
+                dispose = false;
+            }
+
+            this.cancellationTokenSource.CancelAfter(this.readTimeout);
+
+            return source;
+        }
+
+        private void StopTimeout(CancellationTokenSource source, bool dispose)
+        {
+            this.cancellationTokenSource.CancelAfter(Timeout.InfiniteTimeSpan);
+            if (dispose)
+            {
+                source.Dispose();
+            }
+        }
+
+        private void UpdateReadTimeout()
+        {
+            if (this.wrappedStream.CanTimeout)
+            {
+                try
+                {
+                    this.wrappedStream.ReadTimeout = (int)this.readTimeout.TotalMilliseconds;
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+
+        private void UpdateWriteTimeout()
+        {
+            if (this.wrappedStream.CanTimeout)
+            {
+                try
+                {
+                    this.wrappedStream.WriteTimeout = (int)this.writeTimeout.TotalMilliseconds;
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                this.cancellationTokenSource.Dispose();
+                this.wrappedStream.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Problem**
This is to address situation when response parsing hangs on reading response stream indefinitely here https://github.com/dotnet/runtime/blob/5d5c36bb9e887cfe50913840ba96985da113640f/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs#L1195 .

The reproduction scenario : https://gist.github.com/brettsam/85950a65fc50da044dee6ec242944895

![image](https://user-images.githubusercontent.com/61715331/80650798-82bdf200-8a29-11ea-8d38-53d47202c7d1.png)

**Solution**
The solution is inspired by V12 where timeouts are enforced by wrapping response stream [ReadTimeoutStream](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs) .
Additionally `ByteCountingStream` wrapper has been fixed - absent override were causing it to use [default implementation](https://github.com/microsoft/referencesource/blob/a7bd3242bd7732dec4aebb21fbc0f6de61c2545e/mscorlib/system/io/stream.cs#L421-L424) - effectively loosing cancellation token and not passing it into http/network stack.

**Extra**
Additionally `WithCancellation` extension has been improved to mark exceptions thrown by abandoned tasks as handled.

**Testing**
I've been running reproduction scenario and observed that after changes it didn't hang but threw cancellation exception.
