### PR TITLE
Fix egress reporting on outgoing data.

### DIFF
--- a/Lib/Common/Core/Util/StreamExtensions.cs
+++ b/Lib/Common/Core/Util/StreamExtensions.cs
@@ -251,11 +251,12 @@ namespace Microsoft.Azure.Storage.Core.Util
         /// </summary>
         /// <param name="stream">A reference to the original stream</param>
         /// <param name="result">An object that represents the result of a physical request.</param>
+        /// <param name="reverseCapture">A flag indicating that ingress/egress bytes should be capture in reverse.</param>
         /// <returns></returns>
         [DebuggerNonUserCode]
-        internal static Stream WrapWithByteCountingStream(this Stream stream, RequestResult result)
+        internal static Stream WrapWithByteCountingStream(this Stream stream, RequestResult result, bool reverseCapture=false)
         {
-            return new ByteCountingStream(stream, result);
+            return new ByteCountingStream(stream, result, reverseCapture);
         }
 #endif
 

--- a/Lib/Common/Shared/Protocol/HttpContentFactory.cs
+++ b/Lib/Common/Shared/Protocol/HttpContentFactory.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Storage.Shared.Protocol
 {
     using Microsoft.Azure.Storage.Core;
     using Microsoft.Azure.Storage.Core.Executor;
+    using Microsoft.Azure.Storage.Core.Util;
     using System;
     using System.IO;
     using System.Net.Http;
@@ -28,7 +29,10 @@ namespace Microsoft.Azure.Storage.Shared.Protocol
         public static HttpContent BuildContentFromStream<T>(Stream stream, long offset, long? length, Checksum checksum, RESTCommand<T> cmd, OperationContext operationContext)
         {
             stream.Seek(offset, SeekOrigin.Begin);
-            
+
+#if !(WINDOWS_RT || NETCORE)
+            stream = stream.WrapWithByteCountingStream(cmd.CurrentResult, true);
+#endif
             HttpContent retContent = new StreamContent(new NonCloseableStream(stream));
             retContent.Headers.ContentLength = length;
             if (checksum?.MD5 != null)


### PR DESCRIPTION
**Changes**
- Fix issue where egress bytes are not reported.
- Add unit test covering that aspect - there wasn't any coverage for that before.

**Root Cause**
This is a regression from at least 9.3.2. The root cause is that [this property](https://github.com/Azure/azure-storage-net/blob/217d521a0c044e68cf1133ef1a5f7c7d37ca7040/Lib/Common/Core/Executor/ExecutionState.cs#L184) has been abandoned over time in favor of `HttpContentFactory`

**Testing**
I've run all 3 platforms and compared with master. No regression from master.