### PR TITLE
Eagerly dispose network stream if timeout occurs.

### DIFF
--- a/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
+++ b/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
@@ -143,9 +143,10 @@ namespace Microsoft.Azure.Storage.Core
                 await this.wrappedStream.FlushAsync(source.Token).ConfigureAwait(false);
             }
             // We dispose stream on timeout so catch and check if cancellation token was cancelled
-            catch (ObjectDisposedException) when (source.IsCancellationRequested)
+            catch (ObjectDisposedException)
             {
-                throw new OperationCanceledException(source.Token);
+                source.Token.ThrowIfCancellationRequested();
+                throw;
             }
             finally
             {
@@ -166,9 +167,10 @@ namespace Microsoft.Azure.Storage.Core
                 return await this.wrappedStream.ReadAsync(buffer, offset, count, source.Token).ConfigureAwait(false);
             }
             // We dispose stream on timeout so catch and check if cancellation token was cancelled
-            catch (ObjectDisposedException) when (source.IsCancellationRequested)
+            catch (ObjectDisposedException)
             {
-                throw new OperationCanceledException(source.Token);
+                source.Token.ThrowIfCancellationRequested();
+                throw;
             }
             finally
             {
@@ -204,9 +206,10 @@ namespace Microsoft.Azure.Storage.Core
                 await this.wrappedStream.WriteAsync(buffer, offset, count, source.Token).ConfigureAwait(false);
             }
             // We dispose stream on timeout so catch and check if cancellation token was cancelled
-            catch (ObjectDisposedException) when (source.IsCancellationRequested)
+            catch (ObjectDisposedException)
             {
-                throw new OperationCanceledException(source.Token);
+                source.Token.ThrowIfCancellationRequested();
+                throw;
             }
             finally
             {


### PR DESCRIPTION
Backport https://github.com/Azure/azure-sdk-for-net/pull/12103 and https://github.com/Azure/azure-sdk-for-net/pull/12113 where underlying stream is eagerly disposed.
For .NET Framework absence of that was not releasing connection causing hangs.

I've run tests against this vs master. no regression.