### PR TITLE
Checking correct parameter for IsNullOrWhiteSpace

### DIFF
--- a/Lib/Common/Shared/Protocol/HttpRequestMessageFactory.cs
+++ b/Lib/Common/Shared/Protocol/HttpRequestMessageFactory.cs
@@ -200,10 +200,10 @@ namespace Microsoft.Azure.Storage.Shared.Protocol
         /// <param name="value">The metadata value.</param>
         internal static void AddMetadata(StorageRequestMessage request, string name, string value)
         {
-            CommonUtility.AssertNotNull("value", value);
-            if (string.IsNullOrWhiteSpace(value))
+            CommonUtility.AssertNotNull(nameof(name), name);
+            if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ArgumentException(SR.ArgumentEmptyError, value);
+                throw new ArgumentException(SR.ArgumentEmptyError, name);
             }
 
             request.Headers.Add("x-ms-meta-" + name, value);


### PR DESCRIPTION
This PR fixed the issue described in #828 

As described in the issue the value can be null or an empty string, but the `name` parameter should never be null and is now checked.