### PR TITLE
Avoid unnecessary exception in TimeoutStream

### DIFF
--- a/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
+++ b/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Storage.Core
 
         private void UpdateReadTimeout()
         {
-            if (this.wrappedStream.CanTimeout)
+            if (this.wrappedStream.CanTimeout && this.wrappedStream.CanRead)
             {
                 try
                 {
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Storage.Core
 
         private void UpdateWriteTimeout()
         {
-            if (this.wrappedStream.CanTimeout)
+            if (this.wrappedStream.CanTimeout && this.wrappedStream.CanWrite)
             {
                 try
                 {

--- a/Lib/WindowsRuntime/Core/TimeoutStream.cs
+++ b/Lib/WindowsRuntime/Core/TimeoutStream.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Storage.Core
 
         private void UpdateReadTimeout()
         {
-            if (this.wrappedStream.CanTimeout)
+            if (this.wrappedStream.CanTimeout && this.wrappedStream.CanRead)
             {
                 try
                 {
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Storage.Core
 
         private void UpdateWriteTimeout()
         {
-            if (this.wrappedStream.CanTimeout)
+            if (this.wrappedStream.CanTimeout && this.wrappedStream.CanWrite)
             {
                 try
                 {


### PR DESCRIPTION
Underlying stream implementation may throw if we try to set a read/write timeout on a non-readable or non-writable stream. Add an additional check to prevent this exception from being thrown.

Since this gets hit on every blob read, the impact is fairly significant for services which download many blobs.

Fixes #1014 