### PR TITLE
Check if can write/read before setting timeout.

### DIFF
--- a/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
+++ b/Lib/ClassLibraryCommon/Core/TimeoutStream.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Storage.Core
 
         private void UpdateReadTimeout()
         {
-            if (this.wrappedStream.CanTimeout)
+            if (this.wrappedStream.CanTimeout && this.wrappedStream.CanRead)
             {
                 try
                 {
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Storage.Core
 
         private void UpdateWriteTimeout()
         {
-            if (this.wrappedStream.CanTimeout)
+            if (this.wrappedStream.CanTimeout && this.wrappedStream.CanWrite)
             {
                 try
                 {


### PR DESCRIPTION
The previously added network timeout (enforcing read/write timeouts in absence of cancellation token) brought in a performance regression heavily manifesting on .NET Framework.

This has been tested by executing population of same request - Queue.DeleteMessage to be precise and measuring latency while changing .net runtime and sdk version.

The regression added additional ~50ms for each request due to an exception being thrown for each request.

I.e. V11.1.3 spent 27ms on average deleting a message from queue. V11.1.7 spent 80ms on average.
After applying fix the performance is back to 28ms.

Surprisingly, on .NET Core performance degradation wasn't that severe.