### PR TITLE
Fix race conditions in BlobWriteStream / OpenWrite

### DIFF
--- a/Lib/Common/Core/Util/AsyncExtensions.Common.cs
+++ b/Lib/Common/Core/Util/AsyncExtensions.Common.cs
@@ -229,7 +229,11 @@ namespace Microsoft.Azure.Storage.Core.Util
 
         public AsyncManualResetEvent(bool initialStateSignaled)
         {
-            Task.Run(() => m_tcs.TrySetResult(initialStateSignaled));
+            if (initialStateSignaled)
+            {
+                // There's nobody awaiting the task nor is there any continuation, so this should be safe to do.
+                m_tcs.SetResult(true);
+            }
         }
 
         public Task WaitAsync() { return m_tcs.Task; }

--- a/Test/ClassLibraryCommon/Core/AsyncManualResetEventTests.cs
+++ b/Test/ClassLibraryCommon/Core/AsyncManualResetEventTests.cs
@@ -1,0 +1,126 @@
+// -----------------------------------------------------------------------------------------
+// <copyright file="AsyncStreamCopierTests.cs" company="Microsoft">
+//    Copyright 2013 Microsoft Corporation
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// </copyright>
+// -----------------------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Storage.Core.Util;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Storage.Core
+{
+    [TestClass]
+    public class AsyncManualResetEventTests
+    {
+        [TestMethod]
+        public void CtorCreateSet()
+        {
+            // arrange
+            var theEvent = new AsyncManualResetEvent(true);
+
+            // act
+            bool completed = theEvent.WaitAsync().Wait(TimeSpan.FromSeconds(2));
+
+            // assert
+            Assert.IsTrue(completed);
+        }
+
+        [TestMethod]
+        public void CtorCreateUnSet()
+        {
+            // arrange
+            var theEvent = new AsyncManualResetEvent(false);
+
+            // act
+            bool completed = theEvent.WaitAsync().Wait(TimeSpan.FromSeconds(2));
+
+            // assert
+            Assert.IsFalse(completed);
+        }
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void ShouldReset(bool initialState)
+        {
+            // arrange
+            var theEvent = new AsyncManualResetEvent(initialState);
+
+            // act
+            theEvent.Reset();
+
+            // assert
+            bool completed = theEvent.WaitAsync().Wait(TimeSpan.FromSeconds(2));
+            Assert.IsFalse(completed);
+        }
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task ShouldResetAfterSequenceOfTransitions(bool initialState)
+        {
+            // arrange
+            var theEvent = new AsyncManualResetEvent(initialState);
+
+            // act
+            await theEvent.Set();
+            theEvent.Reset();
+            await theEvent.Set();
+            theEvent.Reset();
+
+            // assert
+            bool completed = theEvent.WaitAsync().Wait(TimeSpan.FromSeconds(2));
+            Assert.IsFalse(completed);
+        }
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task ShouldSet(bool initialState)
+        {
+            // arrange
+            var theEvent = new AsyncManualResetEvent(initialState);
+
+            // act
+            await theEvent.Set();
+
+            // assert
+            bool completed = theEvent.WaitAsync().Wait(TimeSpan.FromSeconds(2));
+            Assert.IsTrue(completed);
+        }
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task ShouldSetAfterSequenceOfTransitions(bool initialState)
+        {
+            // arrange
+            var theEvent = new AsyncManualResetEvent(initialState);
+
+            // act
+            await theEvent.Set();
+            theEvent.Reset();
+            await theEvent.Set();
+            theEvent.Reset();
+            await theEvent.Set();
+
+            // assert
+            bool completed = theEvent.WaitAsync().Wait(TimeSpan.FromSeconds(2));
+            Assert.IsTrue(completed);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR addresses https://github.com/Azure/azure-storage-net/issues/780 .

The repro has been established here https://github.com/kasobol-msft/azure-storage-net/commit/32f243196be7fc013e02da7e2f895ae32d848700 . Then the fix has been found here https://github.com/kasobol-msft/azure-storage-net/commit/7df5f741eb9b74a10c94f98ece93082b6b89aee4 by trial and error.

The patched version has been running repro program for several hours without an issue. (All the races were discoverable after minutes of run previously).

The races found:

Initialization in ctor could complete later (scheduled on thread pool) in the middle of stream-write-flush-close cycle disrupting synchronization flow:
https://github.com/Azure/azure-storage-net/blob/b0d47bfd4c1c0dcbe60eaf373e2977cd7405aa5f/Lib/Common/Core/Util/AsyncExtensions.Common.cs#L230-L233

Counter event could "Set" the `internalEvent` while "Increment" concurrent increment was going on. This should have been part of critical section:
https://github.com/Azure/azure-storage-net/blob/b0d47bfd4c1c0dcbe60eaf373e2977cd7405aa5f/Lib/Common/Core/Util/CounterEvent.cs#L53-L56

In `BlobWriteStream`. If single `WriteAsync` was divided into multiple `DispatchWriteAsync` then `WriteAsync` awaited only on first `DispatchWriteAsync` to increment `noPendingWritesEvent` leading to prepature release of wait in `FlushAsync`
https://github.com/Azure/azure-storage-net/blob/b0d47bfd4c1c0dcbe60eaf373e2977cd7405aa5f/Lib/ClassLibraryCommon/Blob/BlobWriteStream.cs#L184-L239
https://github.com/Azure/azure-storage-net/blob/b0d47bfd4c1c0dcbe60eaf373e2977cd7405aa5f/Lib/ClassLibraryCommon/Blob/BlobWriteStream.cs#L510-L519
https://github.com/Azure/azure-storage-net/blob/b0d47bfd4c1c0dcbe60eaf373e2977cd7405aa5f/Lib/ClassLibraryCommon/Blob/BlobWriteStream.cs#L308

In `BlobWriteStream`. Flush could not be waiting enough for last `DispatchWriteAsync` to increment `noPendingWritesEvent`. I.e. no TCS has been provided to `DispatchWriteAsync` to guard against that.
https://github.com/Azure/azure-storage-net/blob/b0d47bfd4c1c0dcbe60eaf373e2977cd7405aa5f/Lib/ClassLibraryCommon/Blob/BlobWriteStream.cs#L307
