### PR TITLE
Truncate visiblityTimeout when updating QueueMessage

### DIFF
--- a/Lib/WindowsRuntime/Queue/Protocol/QueueHttpRequestMessageFactory.cs
+++ b/Lib/WindowsRuntime/Queue/Protocol/QueueHttpRequestMessageFactory.cs
@@ -201,7 +201,8 @@ namespace Microsoft.Azure.Storage.Queue.Protocol
             builder.Add(Constants.QueryConstants.PopReceipt, popReceipt);
             if (visibilityTimeout != null)
             {
-                builder.Add(Constants.QueryConstants.VisibilityTimeout, visibilityTimeout.Value.TotalSeconds.ToString());
+                var totalSeconds = (long) visibilityTimeout.Value.TotalSeconds;
+                builder.Add(Constants.QueryConstants.VisibilityTimeout, totalSeconds.ToString());
             }
             else
             {


### PR DESCRIPTION
The server will reject requests that do not use an integer value of seconds for visiblity. The AddMessage method already addresses this by using a `long` number of seconds, but UpdateMessage takes a TimeSpan and will include fractional seconds allowing for requests that will always be rejected. This PR addresses the problem by truncating any fractional seconds when creating a Queue request.